### PR TITLE
fix: update database configuration keys for PostgreSQL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,11 @@ def get_database_configuration():
         print("\nPostgreSQL Configuration:")
         config = {
             "DATABASE_BACKEND": "postgresql",
-            "DB_HOST": input("Host [localhost]: ").strip() or "localhost",
-            "DB_PORT": input("Port [5432]: ").strip() or "5432",
-            "DB_NAME": input("Database [cnpj]: ").strip() or "cnpj",
-            "DB_USER": input("User [postgres]: ").strip() or "postgres",
-            "DB_PASSWORD": input("Password: ").strip(),
+            "POSTGRES_HOST": input("Host [localhost]: ").strip() or "localhost",
+            "POSTGRES_PORT": input("Port [5432]: ").strip() or "5432",
+            "POSTGRES_NAME": input("Database [cnpj]: ").strip() or "cnpj",
+            "POSTGRES_USER": input("User [postgres]: ").strip() or "postgres",
+            "POSTGRES_PASSWORD": input("Password: ").strip(),
         }
         return config
     else:


### PR DESCRIPTION
to match variables used in `src/config.py::Config`


```py
    # PostgreSQL settings
    db_host: str = field(
        default_factory=lambda: os.getenv("POSTGRES_HOST", "localhost")
    )
    db_port: int = field(default_factory=lambda: _get_int_env("POSTGRES_PORT", "5432"))
    db_name: str = field(default_factory=lambda: os.getenv("POSTGRES_DB", "cnpj"))
    db_user: str = field(default_factory=lambda: os.getenv("POSTGRES_USER", "postgres"))
    db_password: str = field(
        default_factory=lambda: os.getenv("POSTGRES_PASSWORD", "postgres")
    )
```