### PR TITLE
fix: remove dots from filenames before matching known CNPJ patterns

### DIFF
--- a/src/download_strategies/base.py
+++ b/src/download_strategies/base.py
@@ -147,18 +147,18 @@ class DownloadStrategy(ABC):
                     "SIMPLESCSV",
                 ]
 
-                for member in zip_ref.namelist():
-                    # Check if member ends with any known CNPJ file pattern
-                    member_upper = member.upper()
-                    is_cnpj_file = any(
-                        member_upper.endswith(pattern) for pattern in known_patterns
-                    )
+            for member in zip_ref.namelist():
+                # Remove pontos do nome do arquivo para facilitar a busca
+                member_upper = member.upper().replace(".", "")
+                is_cnpj_file = any(
+                    pattern in member_upper for pattern in known_patterns
+                )
 
-                    if is_cnpj_file:
-                        extract_path = self.temp_path / member
-                        zip_ref.extract(member, self.temp_path)
-                        extracted_files.append(extract_path)
-                        logger.debug(f"Extracted CNPJ file: {member}")
+                if is_cnpj_file:
+                    extract_path = self.temp_path / member
+                    zip_ref.extract(member, self.temp_path)
+                    extracted_files.append(extract_path)
+                    logger.debug(f"Extracted CNPJ file: {member}")
 
             logger.debug(f"Extracted {len(extracted_files)} CSV files from {filename}")
 


### PR DESCRIPTION
Remoção dos pontos no nome do arquivo e verificação de substring.