### PR TITLE
feat(recipes): add empresas_busca_nome.sql (recipeVersion 1)

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -14,6 +14,7 @@ A regra está em [../docs/post-processing.md](../docs/post-processing.md): o pip
 | `cnae_secundaria_exploded` | [`postgres/cnae_secundaria_exploded.sql`](postgres/cnae_secundaria_exploded.sql) | Transforma `cnae_fiscal_secundaria` em uma tabela lateral: uma linha por CNAE secundário. |
 | `socios_quality_flags` | [`postgres/socios_quality_flags.sql`](postgres/socios_quality_flags.sql) | Mede sinais de qualidade por sócio, incluindo representante legal com valor de preenchimento e referências ausentes. |
 | `socios_clean` | [`postgres/socios_clean.sql`](postgres/socios_clean.sql) | Usa `socios_quality_flags` para emitir pares cru/limpo do trio do representante e de `faixa_etaria`. |
+| `empresas_busca_nome` | [`postgres/empresas_busca_nome.sql`](postgres/empresas_busca_nome.sql) | Tabela de serviço para busca por `razao_social` em matrizes ativas. Inclui descrições de município e CNAE e índices compostos para LIKE prefixo combinado com filtros de UF, município ou CNAE. |
 
 ## Como aplicar
 
@@ -33,6 +34,9 @@ psql "$DATABASE_URL" -f recipes/postgres/cnae_secundaria_exploded.sql
 # Sinais de qualidade e camada limpa por sócio
 psql "$DATABASE_URL" -f recipes/postgres/socios_quality_flags.sql
 psql "$DATABASE_URL" -f recipes/postgres/socios_clean.sql
+
+# Tabela de serviço para busca por nome em matrizes ativas
+psql "$DATABASE_URL" -f recipes/postgres/empresas_busca_nome.sql
 ```
 
 Rode novamente após cada carga mensal para atualizar. Quando uma receita depende de outra, isso aparece no cabeçalho do SQL.

--- a/recipes/postgres/empresas_busca_nome.sql
+++ b/recipes/postgres/empresas_busca_nome.sql
@@ -1,0 +1,120 @@
+-- recipes/postgres/empresas_busca_nome.sql
+--
+-- recipeVersion: 1
+-- depends on: empresas, estabelecimentos, cnaes, municipios (base pipeline tables)
+--
+-- Search-by-name serving table for the most common access pattern over
+-- the CNPJ dataset: "find an active headquarters by razao_social prefix,
+-- optionally narrowed by UF / município / CNAE, ordered by name."
+--
+-- Filters to active matriz only:
+--   - situacao_cadastral = '02'        (active)
+--   - identificador_matriz_filial = 1  (headquarters, not branches)
+--
+-- Branches and inactive companies are intentionally excluded. Consumers
+-- that need those rows can query estabelecimentos directly or build a
+-- companion recipe with a different predicate.
+--
+-- Apply after the pipeline finishes ingest:
+--     psql "$DATABASE_URL" -f recipes/postgres/empresas_busca_nome.sql
+--
+-- Re-run after each monthly ingest to refresh.
+--
+-- Design choices:
+--   - One row per matching estabelecimento. The active-matriz predicate
+--     normally yields one row per company per snapshot, but the source
+--     does not enforce that invariant and the recipe does not assume it.
+--   - cnpj column is materialized as basico||ordem||dv, the same pattern
+--     as empresa_detalhe.sql. Lets consumers point-lookup by the
+--     14-digit string without repeating the concatenation.
+--   - Source codes are preserved alongside denormalized descriptions
+--     (municipio_codigo + municipio_nome, cnae_fiscal_principal +
+--     cnae_descricao) so consumers can re-join the reference tables
+--     for richer surfaces without re-querying the base.
+--   - Composite indexes cover (filter, razao_social, PK-suffix) to
+--     support prefix filtering and common ordering patterns. They do
+--     not guarantee a sort-free plan in every case; verify with EXPLAIN
+--     for your workload, especially under non-default collations or
+--     when stacking multiple filters.
+--   - text_pattern_ops on razao_social enables LIKE 'PREFIX%' index use.
+--     Substring LIKE ('%PREFIX%') needs GIN + pg_trgm; see the opt-in
+--     block at the bottom.
+
+DROP TABLE IF EXISTS empresas_busca_nome;
+
+CREATE TABLE empresas_busca_nome AS
+SELECT
+    e.cnpj_basico,
+    est.cnpj_ordem,
+    est.cnpj_dv,
+    e.cnpj_basico || est.cnpj_ordem || est.cnpj_dv AS cnpj,
+    e.razao_social,
+    est.nome_fantasia,
+    est.uf,
+    est.municipio AS municipio_codigo,
+    m.descricao AS municipio_nome,
+    est.situacao_cadastral,
+    est.identificador_matriz_filial,
+    est.cnae_fiscal_principal,
+    c.descricao AS cnae_descricao,
+    est.data_inicio_atividade
+FROM empresas e
+JOIN estabelecimentos est USING (cnpj_basico)
+LEFT JOIN cnaes c ON c.codigo = est.cnae_fiscal_principal
+LEFT JOIN municipios m ON m.codigo = est.municipio
+WHERE est.situacao_cadastral = '02'
+  AND est.identificador_matriz_filial = 1;
+
+-- Primary key on the component CNPJ tuple. Covers point-lookup access
+-- and gives every secondary index a small unique-suffix tiebreaker.
+ALTER TABLE empresas_busca_nome
+    ADD CONSTRAINT pk_empresas_busca_nome
+    PRIMARY KEY (cnpj_basico, cnpj_ordem, cnpj_dv);
+
+-- Single-column index on the materialized cnpj for callers that look
+-- up by the concatenated 14-digit string instead of the component tuple.
+CREATE INDEX IF NOT EXISTS idx_empresas_busca_nome_cnpj
+    ON empresas_busca_nome (cnpj);
+
+-- Prefix LIKE on razao_social plus the PK suffix as a tiebreaker.
+-- Supports the LIKE 'PREFIX%' predicate; whether Postgres can use it to
+-- avoid a sort under a specific ORDER BY depends on collation and the
+-- rest of the query (see the EXPLAIN note in the header).
+CREATE INDEX IF NOT EXISTS idx_empresas_busca_nome_razao_prefix
+    ON empresas_busca_nome
+    (razao_social text_pattern_ops, cnpj_basico, cnpj_ordem);
+
+-- UF filter + sort by razao_social.
+CREATE INDEX IF NOT EXISTS idx_empresas_busca_nome_uf_razao
+    ON empresas_busca_nome
+    (uf, razao_social, cnpj_basico, cnpj_ordem);
+
+-- UF + município (denormalized name) + sort. Indexes municipio_nome
+-- because that's typically what consumer-facing filters expose. Add a
+-- parallel index on municipio_codigo if your callers filter by RFB code.
+CREATE INDEX IF NOT EXISTS idx_empresas_busca_nome_uf_municipio_razao
+    ON empresas_busca_nome
+    (uf, municipio_nome, razao_social, cnpj_basico, cnpj_ordem);
+
+-- UF + CNAE + sort by razao_social.
+CREATE INDEX IF NOT EXISTS idx_empresas_busca_nome_uf_cnae_razao
+    ON empresas_busca_nome
+    (uf, cnae_fiscal_principal, razao_social, cnpj_basico, cnpj_ordem);
+
+ANALYZE empresas_busca_nome;
+
+-- Optional: substring LIKE on razao_social via trigram GIN.
+-- Uncomment if you need LIKE '%PREFIX%' (or ILIKE) patterns. The index
+-- is significantly larger than the b-tree indexes above and refresh is
+-- slower; only enable when substring search is a real requirement.
+--
+--   CREATE EXTENSION IF NOT EXISTS pg_trgm;
+--   CREATE INDEX IF NOT EXISTS idx_empresas_busca_nome_razao_trgm
+--       ON empresas_busca_nome
+--       USING gin (razao_social gin_trgm_ops);
+
+-- Storage check (run separately):
+--   SELECT
+--       pg_size_pretty(pg_total_relation_size('empresas_busca_nome')) AS total,
+--       pg_size_pretty(pg_relation_size('empresas_busca_nome')) AS heap,
+--       pg_size_pretty(pg_indexes_size('empresas_busca_nome')) AS indexes;

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1002,3 +1002,140 @@ class TestRecipeSociosClean:
 
         count_after = _count_rows(test_db, "socios_clean")
         assert count_before == count_after, f"Re-running recipe changed row count: {count_before} -> {count_after}"
+
+
+class TestRecipeEmpresasBuscaNome:
+    """Apply recipes/postgres/empresas_busca_nome.sql against the fixture-loaded
+    database and verify the search-serving table has the expected shape.
+
+    Depends on test_db being populated by TestFullPipeline; pytest runs
+    classes in file order so the fixture state from earlier tests is
+    available here.
+    """
+
+    RECIPE_PATH = Path(__file__).parent.parent / "recipes" / "postgres" / "empresas_busca_nome.sql"
+
+    def test_recipe_executes(self, test_db):
+        """The recipe SQL should parse and execute without errors."""
+        sql = self.RECIPE_PATH.read_text()
+        with test_db.conn.cursor() as cur:
+            cur.execute(sql)
+        test_db.conn.commit()
+
+        with test_db.conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM information_schema.tables WHERE table_name = 'empresas_busca_nome'")
+            assert cur.fetchone() is not None, "empresas_busca_nome table not created"
+
+    def test_row_count_matches_active_matriz_join(self, test_db):
+        """Row count must equal empresas JOIN estabelecimentos USING (cnpj_basico)
+        filtered to active matriz. LEFT JOINs on cnaes and municipios must
+        not add or drop rows."""
+        with test_db.conn.cursor() as cur:
+            cur.execute("""
+                SELECT COUNT(*) FROM empresas e
+                JOIN estabelecimentos est USING (cnpj_basico)
+                WHERE est.situacao_cadastral = '02'
+                  AND est.identificador_matriz_filial = 1
+            """)
+            expected = cur.fetchone()[0]
+
+        actual = _count_rows(test_db, "empresas_busca_nome")
+        assert actual > 0, "empresas_busca_nome is empty - fixture has no active-matriz overlap"
+        assert actual == expected, (
+            f"empresas_busca_nome ({actual}) != active-matriz join ({expected}) - "
+            "reference LEFT JOINs on cnaes/municipios must preserve all rows"
+        )
+
+    def test_only_active_matriz_rows(self, test_db):
+        """Every row must satisfy the filter predicate. Guards against the
+        WHERE clause being weakened or against the type comparison drifting
+        (identificador_matriz_filial is INTEGER, situacao_cadastral is text)."""
+        with test_db.conn.cursor() as cur:
+            cur.execute("""
+                SELECT COUNT(*) FROM empresas_busca_nome
+                WHERE situacao_cadastral <> '02'
+                   OR identificador_matriz_filial <> 1
+            """)
+            violations = cur.fetchone()[0]
+        assert violations == 0, f"{violations} rows violate the active-matriz predicate"
+
+    def test_cnpj_column_is_concatenation(self, test_db):
+        """cnpj column = cnpj_basico || cnpj_ordem || cnpj_dv, same convention
+        as empresa_detalhe."""
+        with test_db.conn.cursor() as cur:
+            cur.execute("""
+                SELECT cnpj, cnpj_basico, cnpj_ordem, cnpj_dv
+                FROM empresas_busca_nome
+                LIMIT 10
+            """)
+            rows = cur.fetchall()
+            assert rows, "no rows to verify cnpj concatenation"
+            for cnpj, basico, ordem, dv in rows:
+                assert cnpj == basico + ordem + dv, f"{cnpj} != {basico}+{ordem}+{dv}"
+                assert len(cnpj) == 14, f"cnpj wrong length: {cnpj}"
+
+    def test_reference_descriptions_joined(self, test_db):
+        """When estabelecimento codes have matching reference rows the
+        denormalized description columns should be populated."""
+        with test_db.conn.cursor() as cur:
+            cur.execute("""
+                SELECT COUNT(*) FROM empresas_busca_nome
+                WHERE cnae_descricao IS NOT NULL
+                  AND municipio_nome IS NOT NULL
+            """)
+            count = cur.fetchone()[0]
+            assert count > 0, "no rows have both cnae_descricao and municipio_nome joined"
+
+    def test_expected_indexes_exist(self, test_db):
+        """The composite indexes that justify the recipe must all be present.
+        If one is dropped or renamed, the recipe no longer provides the
+        documented access path."""
+        with test_db.conn.cursor() as cur:
+            cur.execute("""
+                SELECT indexname FROM pg_indexes
+                WHERE tablename = 'empresas_busca_nome'
+            """)
+            indexes = {row[0] for row in cur.fetchall()}
+
+        expected = {
+            "pk_empresas_busca_nome",
+            "idx_empresas_busca_nome_cnpj",
+            "idx_empresas_busca_nome_razao_prefix",
+            "idx_empresas_busca_nome_uf_razao",
+            "idx_empresas_busca_nome_uf_municipio_razao",
+            "idx_empresas_busca_nome_uf_cnae_razao",
+        }
+        missing = expected - indexes
+        assert not missing, f"missing expected indexes: {missing}"
+
+    def test_no_derived_columns_leaked(self, test_db):
+        """The recipe filters rows but does not synthesize labels or
+        booleans. Source codes stay; no is_ativa, no situacao_cadastral_descricao."""
+        with test_db.conn.cursor() as cur:
+            cur.execute("""
+                SELECT column_name FROM information_schema.columns
+                WHERE table_name = 'empresas_busca_nome'
+            """)
+            cols = {row[0] for row in cur.fetchall()}
+
+        forbidden = {
+            "is_ativa",
+            "is_matriz",
+            "situacao_cadastral_descricao",
+            "identificador_matriz_filial_descricao",
+        }
+        leaked = cols & forbidden
+        assert not leaked, f"recipe leaked opinionated columns: {leaked}"
+
+    def test_idempotent(self, test_db):
+        """Re-running the recipe should drop+recreate without error and
+        produce the same row count."""
+        sql = self.RECIPE_PATH.read_text()
+        count_before = _count_rows(test_db, "empresas_busca_nome")
+
+        with test_db.conn.cursor() as cur:
+            cur.execute(sql)
+        test_db.conn.commit()
+
+        count_after = _count_rows(test_db, "empresas_busca_nome")
+        assert count_before == count_after, f"re-running recipe changed row count: {count_before} -> {count_after}"


### PR DESCRIPTION
Adds a search-by-name serving table for the most common access pattern over the CNPJ dataset: find an active headquarters by `razao_social` prefix, optionally narrowed by UF, município, or CNAE.

- Filters to active matriz (`situacao_cadastral = '02'`, `identificador_matriz_filial = 1`) so consumers don't have to repeat the predicate.
- Materializes `cnpj` as `basico||ordem||dv`, matching the `empresa_detalhe` convention.
- Composite indexes cover `text_pattern_ops` prefix LIKE combined with the common UF / município / CNAE filter shapes. The header notes that sort-free plans aren't guaranteed under every collation, so consumers should `EXPLAIN` their workload.
- Substring search (pg_trgm GIN) is opt-in via a commented block at the bottom; off by default since GIN refresh is heavier.

Integration tests in `tests/test_integration.py` mirror the existing recipe-test style: executes, row count equals the active-matriz join cardinality, every row satisfies the predicate, cnpj concat correctness, reference descriptions populate, expected indexes are present, idempotent under re-run.