### PR TITLE
feat(database): pass DATABASE_URL DSN through to psycopg2 (#79)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 
 # Database (PostgreSQL via Docker on port 5435)
 DATABASE_URL=postgres://postgres:postgres@localhost:5435/cnpj
+# Query-string params are passed through to libpq (sslmode, options, application_name, connect_timeout, ...).
+# Examples:
+#   DATABASE_URL=postgres://user:pass@host:5432/cnpj?sslmode=require
+#   DATABASE_URL=postgres://user:pass@host:5432/cnpj?sslmode=require&options=-c%20search_path%3Dcnpj
 
 # Processing
 BATCH_SIZE=500000

--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ PARQUET_TYPED_OUTPUT=false  # Quando true, datas e numéricos saem tipados (Date
 PROCESS_WORKERS=1        # Arquivos do mesmo grupo em paralelo (ex: 4)
 ```
 
+### `DATABASE_URL`: parâmetros libpq
+
+O `DATABASE_URL` é repassado direto ao driver, então qualquer parâmetro suportado pelo libpq funciona via query string. Útil para Postgres gerenciado (Railway, RDS, Supabase, Neon) e para isolar o pipeline em um schema próprio.
+
+Sempre coloque o valor entre aspas no shell: o `&` da query string é metacaractere e, sem aspas, faz o bash colocar o comando em background.
+
+```bash
+# SSL obrigatório
+DATABASE_URL='postgres://user:pass@host:5432/cnpj?sslmode=require'
+
+# Pipeline em schema separado
+DATABASE_URL='postgres://user:pass@host:5432/cnpj?options=-c%20search_path%3Dcnpj'
+
+# Combinado
+DATABASE_URL='postgres://user:pass@host:5432/cnpj?sslmode=require&options=-c%20search_path%3Dcnpj'
+```
+
+Sobre `search_path`: o schema precisa existir antes (`CREATE SCHEMA cnpj;`), o libpq não cria. Se você incluir `public` como fallback (`search_path=cnpj,public`) e o `public` já tiver tabelas do pipeline de uma execução anterior, o bootstrap (`ensure_schema`) detecta as tabelas no `public` e não cria nada no `cnpj`. Para isolamento estrito, deixe só `cnpj` no `search_path`, ou use um banco novo.
+
 ### Estratégia de carga (PostgreSQL)
 
 | Estratégia | Comando | Quando usar |

--- a/database.py
+++ b/database.py
@@ -6,7 +6,6 @@ import os
 import time
 from pathlib import Path
 from typing import List, Set
-from urllib.parse import urlparse
 
 import polars as pl
 import psycopg2
@@ -27,26 +26,19 @@ class Database:
         self._truncated_tables: set = set(pre_truncated) if pre_truncated else set()
         self.conn = None
 
-    def _parse_url(self) -> dict:
-        """Parse DATABASE_URL into connection parameters."""
-        parsed = urlparse(self.database_url)
-        return {
-            "host": parsed.hostname,
-            "port": parsed.port or 5432,
-            "database": parsed.path[1:],
-            "user": parsed.username,
-            "password": parsed.password,
-        }
-
     def connect(self):
-        """Establish database connection with retry."""
+        """Establish database connection with retry.
+
+        Passes DATABASE_URL through to libpq verbatim so query-string
+        parameters (sslmode, options, application_name, connect_timeout,
+        multi-host URIs, etc.) reach the driver.
+        """
         if self.conn is not None:
             return
 
-        params = self._parse_url()
         for attempt in range(self.retry_attempts):
             try:
-                self.conn = psycopg2.connect(**params)
+                self.conn = psycopg2.connect(self.database_url)
                 self.conn.autocommit = False
                 return
             except psycopg2.OperationalError:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -22,23 +22,6 @@ def connected_db(db):
     return db
 
 
-class TestParseUrl:
-    """Test DATABASE_URL parsing."""
-
-    def test_parses_full_url(self, db):
-        params = db._parse_url()
-        assert params["host"] == "localhost"
-        assert params["port"] == 5432
-        assert params["database"] == "testdb"
-        assert params["user"] == "user"
-        assert params["password"] == "pass"
-
-    def test_default_port(self):
-        db = Database("postgresql://user:pass@localhost/testdb")
-        params = db._parse_url()
-        assert params["port"] == 5432
-
-
 class TestConnect:
     """Test connection with retry logic."""
 
@@ -51,6 +34,28 @@ class TestConnect:
 
         assert db.conn is mock_conn
         assert mock_conn.autocommit is False
+
+    @patch("database.psycopg2.connect")
+    def test_passes_dsn_verbatim(self, mock_connect, db):
+        """The full DATABASE_URL must reach libpq unchanged so query-string
+        params (sslmode, options, application_name, multi-host URIs) survive.
+        """
+        mock_connect.return_value = MagicMock()
+
+        db.connect()
+
+        mock_connect.assert_called_once_with("postgresql://user:pass@localhost:5432/testdb")
+
+    @patch("database.psycopg2.connect")
+    def test_preserves_query_string_params(self, mock_connect):
+        """sslmode and options must not be dropped on the way to psycopg2."""
+        url = "postgresql://u:p@h:5432/db?sslmode=require&options=-csearch_path%3Dcnpj"
+        db = Database(url)
+        mock_connect.return_value = MagicMock()
+
+        db.connect()
+
+        mock_connect.assert_called_once_with(url)
 
     @patch("database.psycopg2.connect")
     def test_noop_when_already_connected(self, mock_connect, db):


### PR DESCRIPTION
Closes #79.

Previously `database.py` parsed `DATABASE_URL` with `urlparse` and forwarded only host/port/database/user/password, silently dropping any query-string params before reaching libpq. Managed Postgres URLs (`?sslmode=require`, `?options=-c%20search_path%3Dcnpj`, `?application_name=...`, multi-host failover URIs) lost the suffix on the way in.

This passes the DSN straight to `psycopg2.connect`, so anything libpq understands works via `DATABASE_URL` alone. Why this and not manual query-string parsing: passthrough also covers parameters we don't currently care about (`target_session_attrs`, `sslrootcert`, future libpq additions) and multi-host URIs that don't survive `urlparse`.

Docs note the `search_path` caveat: the target schema must exist before connecting, and including `public` as fallback can make `ensure_schema()` short-circuit if a previous run left tables there.