### PR TITLE
docs: move socios upgrade instructions to docs/upgrading.md (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,23 +189,10 @@ EMPRESAS (1) ─── (N) ESTABELECIMENTOS
          └─── (1) DADOS_SIMPLES
 ```
 
-### Recarga necessária após o fix do #78
-
-A PK antiga de `socios` era `(cnpj_basico, identificador_de_socio, cnpj_cpf_do_socio)`. Por design da Receita, `cnpj_cpf_do_socio` para pessoa física é o CPF descaracterizado (`***NNNNNN**`): os 3 primeiros e os 2 últimos dígitos ficam ocultos. É campo de exibição, não identificador. Duas pessoas diferentes podem legitimamente compartilhar os 6 dígitos visíveis. Sócios estrangeiros, por sua vez, não têm CPF na fonte e o pipeline preenche com zeros, criando uma segunda classe de colisão.
-
-O bug é antigo; só ficou visível agora. Em maio de 2026 uma colisão entre dois sócios PF da mesma empresa fez o modo `replace` quebrar com `duplicate key value violates unique constraint`. O modo `upsert` já vinha descartando silenciosamente o segundo sócio via `DISTINCT ON` quando isso acontecia (e acontecia mais do que parecia, principalmente entre estrangeiros com CPF zerado).
-
-A nova PK `socios.socio_id` é um UUID determinístico derivado do tuple de identidade. Serve só para a linha bruta caber no banco sem perda. Identidade de negócio (mesma pessoa entre meses, dedup por nome, etc.) fica para receitas, onde cada caso de uso decide a regra.
-
-Bancos já carregados precisam recriar `socios` e as tabelas-receita derivadas (`socios_quality_flags`, `socios_clean`). Não há migração in-app: linhas que o `upsert` já perdeu só voltam com uma recarga completa.
-
-```bash
-psql "$DATABASE_URL" -c 'DROP TABLE IF EXISTS socios_clean, socios_quality_flags, socios CASCADE;'
-psql "$DATABASE_URL" -f initial.sql
-just run --force
-```
-
-O `psql -f initial.sql` é necessário porque `ensure_schema()` só roda em bancos sem `processed_files`. Como aqui só estamos derrubando `socios` (e tabelas-receita), o bootstrap automático não dispara; o `initial.sql` recria as tabelas via `CREATE TABLE IF NOT EXISTS` sem mexer no resto.
+> [!IMPORTANT]
+> Se você já carregou dados antes da mudança para `socios.socio_id`, recrie `socios` e as receitas derivadas (`socios_quality_flags`, `socios_clean`) para preservar sócios com CPF mascarado ou documento ausente.
+>
+> Veja o passo a passo em [docs/upgrading.md](docs/upgrading.md#sociossocio_id).
 
 ## Fonte de Dados
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,24 @@
+# Atualizando bancos existentes
+
+## `socios.socio_id`
+
+A tabela `socios` agora usa `socio_id` como chave primária (issue #78).
+
+Antes, a chave dependia de `cnpj_cpf_do_socio`, mas esse campo não é único na base pública da Receita: CPFs vêm mascarados (`***NNNNNN**`, só os 6 dígitos do meio aparecem) e sócios estrangeiros podem vir sem CPF. Isso podia causar erro na carga ou deixar linhas de fora silenciosamente, dependendo do `LOADING_STRATEGY` em uso.
+
+Para recarregar só `socios` e as receitas derivadas, troque `2026-05` pelo mês carregado no seu banco:
+
+```bash
+psql "$DATABASE_URL" -c 'DROP TABLE IF EXISTS socios_clean, socios_quality_flags, socios CASCADE;'
+psql "$DATABASE_URL" -f initial.sql
+psql "$DATABASE_URL" -c "DELETE FROM processed_files WHERE directory = '2026-05' AND filename ILIKE 'Socios%.zip';"
+just run --month 2026-05
+```
+
+O `psql -f initial.sql` é necessário porque `ensure_schema()` só roda em bancos sem `processed_files`. Derrubar apenas `socios` (e as tabelas-receita) não dispara o bootstrap automático.
+
+Se preferir recarregar o mês inteiro em vez de só sócios:
+
+```bash
+just run --month 2026-05 --force
+```


### PR DESCRIPTION
Follow-up to #81 (merged as v1.29.1).

The README section "Recarga necessária após o fix do #78" was carrying a full incident narrative, a schema explanation, and the recovery recipe at the root of the README. That mix doesn't belong on the front door of the project: an existing user hit by the bug needs the recipe, but new visitors don't need the migration history forever.

This PR:

- moves the explanation and the recovery recipe to `docs/upgrading.md`, with `socios.socio_id` as the first entry. Future breaking schema changes get an established place to land.
- compresses the README content to a short `[!IMPORTANT]` alert that links into the new doc.
- switches the recovery recipe's default to a surgical socios-only reload (delete only `Socios%` entries from `processed_files`, no `--force`). Issue #78 only affects socios, so reloading empresas/estabelecimentos/refs costs ~45 min for no benefit. The full `--force` recipe stays documented as an alternative.

`docs/data-schema.md` already documents `socio_id` as the PK from #81; no changes needed there.

Verified the README anchor resolves to the heading: `## \`socios.socio_id\`` produces the GitHub anchor `#sociossocio_id` (dots stripped, backticks stripped, lowercased).

After merge: edit the GitHub Release body for v1.29.1 to add a link to `docs/upgrading.md`, and comment on issue #78 with the same link.
