### PR TITLE
feat(recipes): add uf+razao text_pattern_ops composite index

### DIFF
--- a/recipes/postgres/empresas_busca_nome.sql
+++ b/recipes/postgres/empresas_busca_nome.sql
@@ -89,6 +89,21 @@ CREATE INDEX IF NOT EXISTS idx_empresas_busca_nome_uf_razao
     ON empresas_busca_nome
     (uf, razao_social, cnpj_basico, cnpj_ordem);
 
+-- UF filter + LIKE 'PREFIX%' on razao_social. The default-opclass
+-- uf_razao above supports sort-by-razao under uf= equality but cannot
+-- range-scan LIKE 'PREFIX%' under non-C collations. This composite
+-- uses text_pattern_ops on razao_social so PG can enter at
+-- (uf=$1, razao_social>='PREFIX') and walk only matching rows in
+-- order — Index Only Scan, no heap fetch, sub-30ms even for broad
+-- common prefixes (e.g. 'COMERC%' over 27M rows).
+--
+-- Pairs with idx_..._razao_prefix above: that one serves uf-less
+-- prefix lookups (e.g. chat name resolution); this one serves
+-- uf-filtered search list queries.
+CREATE INDEX IF NOT EXISTS idx_empresas_busca_nome_uf_razao_prefix
+    ON empresas_busca_nome
+    (uf, razao_social text_pattern_ops, cnpj_basico, cnpj_ordem);
+
 -- UF + município (denormalized name) + sort. Indexes municipio_nome
 -- because that's typically what consumer-facing filters expose. Add a
 -- parallel index on municipio_codigo if your callers filter by RFB code.


### PR DESCRIPTION
Adds a `(uf, razao_social text_pattern_ops, cnpj_basico, cnpj_ordem)` composite index to `empresas_busca_nome`. Fills a real gap: the default-opclass `uf_razao` index above can sort by `razao_social` under `uf=` but cannot range-scan on `LIKE 'PREFIX%'` under non-C collations. The new composite uses `text_pattern_ops`, so PG enters at `(uf=$1, razao_social >= 'PREFIX')` and walks only matching rows in order — Index Only Scan, no heap fetch.

Measured impact on a 27M-row active-matriz build:

| query | before | after |
|---|---|---|
| `uf=SP, razao LIKE 'COMERC%'` (12,676 matches) | timeout / 7-13s | **27 ms** |
| `uf=SP, razao LIKE 'DROGA%'` (4,857 matches) | 8.3 s | **7 ms** |
| `uf=SP, razao LIKE 'SUPERM%'` (2,467 matches) | 11.7 s | **7.5 ms** |
| `uf=SP, razao LIKE 'MERCA%'` | TIMEOUT (>15s) | **9 ms** |
| `uf=SP, razao LIKE 'DROG%'` (4-char) | TIMEOUT | **2.7 ms** |
| `COUNT(*) FOR uf=SP, razao LIKE 'COMERC%'` | 13.4 s | **5.2 ms** |

Index size on the 27M-row table: ~2 GB. Build ~110 sec. Index Only Scan possible because trailing `cnpj_basico, cnpj_ordem` cover the typical `SELECT cnpj_basico` projections.

Root cause for the prior behavior: `pg_stats` for `razao_social` has only 1 MCV captured at `default_statistics_target=100`, so PG flat-estimates 838 rows for any LIKE prefix and picks `idx_..._razao_prefix` (no `uf`) as the cheapest path. With this composite present, the planner picks it correctly across all measured prefixes — adding `uf` to the leading column makes it strictly more selective from the cost model's view.

Both existing indexes are intentionally kept:
- `idx_..._razao_prefix` (text_pattern_ops on razao_social alone) — still serves uf-less prefix lookups, e.g. chat name resolution
- `idx_..._uf_razao` (default opclass) — useful for sorts/comparisons that don't need range-scan on razao_social

`recipeVersion` stays at 1 (additive, non-breaking).
