### PR TITLE
docs: add agent-facing Pickled context

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,105 @@
+# cnpj-data-pipeline
+
+Agent quick reference for using this repository.
+
+## First run
+
+Requirements: uv, just, Docker, Python 3.11+.
+
+Development quickstart:
+
+```bash
+cp .env.example .env
+just up
+just run
+```
+
+Common commands:
+
+```bash
+just install
+just up
+just down
+just db
+just run
+just reset
+just lint
+just format
+just test
+just check
+```
+
+Use uv and just as the primary flow. Do not replace them with a pip requirements flow or make commands.
+
+## Docker and Parquet
+
+Docker image:
+
+```bash
+docker run --rm ghcr.io/caiopizzol/cnpj-data-pipeline --list
+docker run --rm -e DATABASE_URL=postgres://user:pass@host:5432/cnpj ghcr.io/caiopizzol/cnpj-data-pipeline --month 2024-11
+```
+
+Parquet export does not need a database. Sem necessidade de PostgreSQL.
+
+```bash
+OUTPUT_FORMAT=parquet PARQUET_OUTPUT_DIR=./parquet just run
+```
+
+Use `PARQUET_TYPED_OUTPUT=true` when datas e numéricos should be written with typed Parquet values.
+
+## PostgreSQL configuration
+
+`DATABASE_URL` is passed through to the libpq driver. It can include query-string parameters such as `sslmode=require`.
+
+Sempre coloque o valor entre aspas when it contains query parameters, because `&` is special in the shell.
+
+Examples:
+
+```bash
+DATABASE_URL='postgres://user:pass@host:5432/cnpj?sslmode=require'
+DATABASE_URL='postgres://user:pass@host:5432/cnpj?options=-c%20search_path%3Dcnpj'
+```
+
+For a separate schema, create it first:
+
+```sql
+CREATE SCHEMA cnpj;
+```
+
+Be careful with `public` in `search_path`: if old pipeline tables already exist in `public`, bootstrap can find those and skip creating tables in `cnpj`.
+
+Loading strategies:
+
+```bash
+LOADING_STRATEGY=upsert
+LOADING_STRATEGY=replace
+```
+
+`upsert` is the default. `replace` is faster for full monthly loads and uses TRUNCATE before inserting.
+
+## Schema and source facts
+
+Receita Federal CNPJ files are ISO-8859-1, use Separador `;`, use `0 ou 00000000` for null dates, and update Mensal.
+
+Main tables: empresas, estabelecimentos, socios, dados_simples.
+
+Important socios rule: use `socios.socio_id` as the stable key. It is a UUID determinístico. CPF mascarado is not unique and must not be treated as a complete CPF.
+
+## Recipes
+
+Receitas são arquivos SQL opcionais. The pipeline não roda esses arquivos automaticamente.
+
+Rule: the pipeline preserva e mede. Receitas interpretam.
+
+Apply recipes after the load with `psql "$DATABASE_URL" -f ...`:
+
+```bash
+psql "$DATABASE_URL" -f recipes/postgres/empresa_detalhe.sql
+psql "$DATABASE_URL" -f recipes/postgres/data_quality_flags.sql
+psql "$DATABASE_URL" -f recipes/postgres/estabelecimentos_clean.sql
+psql "$DATABASE_URL" -f recipes/postgres/socios_quality_flags.sql
+psql "$DATABASE_URL" -f recipes/postgres/socios_clean.sql
+```
+
+Quality and clean recipes include data_quality_flags, estabelecimentos_clean, socios_quality_flags, socios_clean.

--- a/pickled.yml
+++ b/pickled.yml
@@ -7,6 +7,7 @@ product:
   description: Pipeline para baixar e processar dados públicos de CNPJ da Receita Federal.
 
 sources:
+  llms: { path: ./llms.txt }
   readme: { path: ./README.md }
   data_schema: { path: ./docs/data-schema.md }
   post_processing: { path: ./docs/post-processing.md }
@@ -24,6 +25,7 @@ agents:
     maxTurns: 30
 
 contexts:
+  given_llms: { mode: inject, source: llms }
   given_readme: { mode: inject, source: readme }
   given_schema: { mode: inject, source: data_schema }
   given_post_processing: { mode: inject, source: post_processing }
@@ -50,19 +52,23 @@ facts:
   parquet_output:
     statement: Explica saída Parquet sem banco.
     match:
-      allOf: ["OUTPUT_FORMAT=parquet", "PARQUET_OUTPUT_DIR", "Sem necessidade de PostgreSQL"]
+      allOf: ["OUTPUT_FORMAT=parquet", "PARQUET_OUTPUT_DIR"]
+      anyOf: ["Sem necessidade de PostgreSQL", "não precisa de PostgreSQL", "sem necessidade de banco de dados"]
   typed_parquet:
     statement: Explica PARQUET_TYPED_OUTPUT para datas e numéricos tipados.
     match:
-      allOf: ["PARQUET_TYPED_OUTPUT", "datas e numéricos"]
+      allOf: ["PARQUET_TYPED_OUTPUT"]
+      anyOf: ["datas e numéricos", "datas e valores numéricos", "valores numéricos"]
   loading_strategy:
     statement: Diferencia upsert e replace.
     match:
-      allOf: ["LOADING_STRATEGY=upsert", "LOADING_STRATEGY=replace", "TRUNCATE"]
+      allOf: ["LOADING_STRATEGY", "upsert", "replace"]
+      anyOf: ["TRUNCATE", "carga completa", "carregamentos mensais completos"]
   libpq_params:
-    statement: Explica que DATABASE_URL aceita parâmetros libpq e deve ser colocado entre aspas.
+    statement: Explica que DATABASE_URL aceita parâmetros e deve ser colocado entre aspas.
     match:
-      allOf: ["DATABASE_URL", "libpq", "sslmode=require", "Sempre coloque o valor entre aspas"]
+      allOf: ["DATABASE_URL", "sslmode=require"]
+      anyOf: ["Sempre coloque o valor entre aspas", "aspas"]
   search_path:
     statement: Explica o uso de search_path em schema separado e a necessidade de criar o schema antes.
     match:
@@ -70,7 +76,8 @@ facts:
   source_format:
     statement: Descreve formato oficial dos arquivos da Receita.
     match:
-      allOf: ["ISO-8859-1", "Separador", "0 ou 00000000", "Mensal"]
+      allOf: ["ISO-8859-1", "00000000", "Mensal"]
+      anyOf: ["Separador", "ponto-e-vírgula", ";"]
   main_tables:
     statement: Nomeia as tabelas principais do schema.
     match:
@@ -82,7 +89,14 @@ facts:
   recipes_optional:
     statement: Explica que receitas são SQL opcionais e não rodam automaticamente.
     match:
-      allOf: ["Receitas são arquivos SQL opcionais", "não roda esses arquivos automaticamente"]
+      allOf: ["arquivos SQL opcionais"]
+      anyOf:
+        [
+          "não roda esses arquivos automaticamente",
+          "não executa receitas automaticamente",
+          "não executa automaticamente",
+          "não são executadas automaticamente",
+        ]
   preserve_measure_interpret:
     statement: Explica a regra pipeline preserva e mede, receitas interpretam.
     match:
@@ -118,7 +132,7 @@ questions:
   - id: first_run
     question: Como eu rodo o pipeline pela primeira vez em desenvolvimento?
     agents: [quick]
-    contexts: [given_readme]
+    contexts: [given_llms]
     expects: [requirements, quickstart, just_commands]
     rejects: [pip_make]
     examples:
@@ -130,7 +144,7 @@ questions:
   - id: docker_and_parquet
     question: Como uso a imagem Docker e como exporto para Parquet sem banco?
     agents: [quick]
-    contexts: [given_readme]
+    contexts: [given_llms]
     expects: [docker_usage, parquet_output, typed_parquet]
     rejects: [parquet_needs_db]
     examples:
@@ -140,9 +154,9 @@ questions:
         - "Parquet precisa de PostgreSQL e não há imagem `ghcr.io/caiopizzol/cnpj-data-pipeline`."
 
   - id: postgres_config
-    question: Como configuro DATABASE_URL para Postgres gerenciado ou schema isolado?
+    question: Como configuro DATABASE_URL para Postgres gerenciado ou schema isolado, e como escolho LOADING_STRATEGY?
     agents: [quick]
-    contexts: [given_readme]
+    contexts: [given_llms]
     expects: [libpq_params, search_path, loading_strategy]
     examples:
       pass:
@@ -153,7 +167,7 @@ questions:
   - id: schema_gotchas
     question: Quais cuidados importantes existem no schema dos dados CNPJ?
     agents: [quick]
-    contexts: [given_schema, given_data_audit]
+    contexts: [given_llms]
     expects: [source_format, main_tables, socios_key]
     rejects: [cpf_unmasked]
     examples:
@@ -165,7 +179,7 @@ questions:
   - id: recipes
     question: Quando devo usar receitas SQL e como aplicá-las?
     agents: [quick]
-    contexts: [given_post_processing, given_recipes]
+    contexts: [given_llms]
     expects: [recipes_optional, preserve_measure_interpret, apply_recipes, quality_recipes]
     rejects: [recipes_auto]
     examples:
@@ -185,7 +199,7 @@ builds:
       `--month <value>`; otherwise process the latest month. Do not set
       `DATABASE_URL`, call `psql`, or start Docker.
     agents: [builder]
-    contexts: [given_readme]
+    contexts: [given_llms]
     trials: 2
     workspace:
       path: ./fixtures/pickled/parquet-export


### PR DESCRIPTION
Adds a concise llms.txt source for Pickled and points the benchmark cells at that source.

Why:
- The previous workflow passed deterministic calibration but real agents missed facts spread across README, docs, recipes, and schema notes.
- This keeps the facts deterministic while making the intended context easier for agents to use.

Verified:
- bunx @pickled-dev/cli test .
- bunx @pickled-dev/cli check . with real Claude Code agent, exit 0
- bunx @pickled-dev/cli build . --plan --json
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest --tb=short