### PR TITLE
feat(cnpj): support alphanumeric CNPJ (Receita 2026-07)

### DIFF
--- a/docs/data-audit.md
+++ b/docs/data-audit.md
@@ -24,7 +24,7 @@ Este documento registra o que a Receita Federal entrega, o que o pipeline normal
 
 | Campo | Forma na fonte | Normalização atual | Possível normalização no núcleo | Receita relacionada | Prioridade |
 |---|---|---|---|---|---|
-| `cnpj_basico` | 8 dígitos, string | validação regex `^\d{8}$` | — | usado em todas | — |
+| `cnpj_basico` | 8 caracteres alfanuméricos (0-9, A-Z), string | validação regex `^[0-9A-Z]{8}$` | — | usado em todas | — |
 | `razao_social` | TEXT, maiúsculas, sem acentos | — | trim de espaços (a confirmar) | — | — |
 | `natureza_juridica` | 4 dígitos, string | validação regex `^\d{4}$` | — | descrição em `empresa_detalhe` | alta |
 | `qualificacao_responsavel` | 2 dígitos, string | validação regex `^\d{2}$` | — | descrição em `empresa_detalhe` (via `qualificacoes_socios_enriched`) | média |
@@ -36,7 +36,7 @@ Este documento registra o que a Receita Federal entrega, o que o pipeline normal
 
 | Campo | Forma na fonte | Normalização atual | Possível normalização no núcleo | Receita relacionada | Prioridade |
 |---|---|---|---|---|---|
-| `cnpj_basico` + `cnpj_ordem` + `cnpj_dv` | strings de 8+4+2 dígitos | — | — | coluna concatenada `cnpj` em `empresa_detalhe` | alta |
+| `cnpj_basico` + `cnpj_ordem` + `cnpj_dv` | strings de 8+4+2: basico/ordem alfanuméricos (`^[0-9A-Z]{8}$` / `^[0-9A-Z]{4}$`), dv numérico (`^\d{2}$`) — ver CNPJ alfanumérico (julho/2026) | — | — | coluna concatenada `cnpj` em `empresa_detalhe` | alta |
 | `identificador_matriz_filial` | "1" \| "2" no CSV, `INTEGER` em PostgreSQL | tipagem via schema | tipado em Parquet (v1.18+) | descrição (`identificador_matriz_filial_descricao`) em `empresa_detalhe`, via `indicadores_matriz_filial` (`reference_domain_labels`) | baixa |
 | `nome_fantasia` | TEXT, maiúsculas, sem acentos | — | trim (a confirmar) | — | — |
 | `situacao_cadastral` | "01" \| "02" \| "03" \| "04" \| "08" | validação regex | — | descrição (`situacao_cadastral_descricao`) em `empresa_detalhe`, via `situacoes_cadastrais` (`reference_domain_labels`); booleanos (`is_ativa`) em receita futura | baixa |
@@ -57,7 +57,7 @@ Este documento registra o que a Receita Federal entrega, o que o pipeline normal
 
 | Campo | Forma na fonte | Normalização atual | Possível normalização no núcleo | Receita relacionada | Prioridade |
 |---|---|---|---|---|---|
-| `cnpj_basico` | 8 dígitos | validação regex | — | — | — |
+| `cnpj_basico` | 8 caracteres alfanuméricos (0-9, A-Z) | validação regex `^[0-9A-Z]{8}$` | — | — | — |
 | `identificador_de_socio` | "1" \| "2" \| "3" | validação regex | — | descrições em `socios_detalhe` | baixa |
 | `nome_socio` | TEXT | — | — | — | — |
 | `cnpj_cpf_do_socio` | já mascarado pela Receita Federal: `***123456**` (CPF) ou CNPJ completo | substitui null por "00000000000000" para manter a chave primária | — | — | — |
@@ -72,7 +72,7 @@ Este documento registra o que a Receita Federal entrega, o que o pipeline normal
 
 | Campo | Forma na fonte | Normalização atual | Possível normalização no núcleo | Receita relacionada | Prioridade |
 |---|---|---|---|---|---|
-| `cnpj_basico` | 8 dígitos, PK | validação regex | — | — | — |
+| `cnpj_basico` | 8 caracteres alfanuméricos (0-9, A-Z), PK | validação regex `^[0-9A-Z]{8}$` | — | — | — |
 | `opcao_pelo_simples` | "S" \| "N" | validação regex | — | incluído cru em `empresa_detalhe` | alta |
 | `data_opcao_pelo_simples`, `data_exclusao_do_simples`, `data_opcao_pelo_mei`, `data_exclusao_do_mei` | YYYYMMDD ou null | normalização de datas | tipado em Parquet (v1.18+) | incluído cru em `empresa_detalhe` | alta |
 | `opcao_pelo_mei` | "S" \| "N" | validação regex | — | incluído cru em `empresa_detalhe` | alta |

--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -39,7 +39,7 @@ erDiagram
 
 | Campo | Descrição |
 |-------|-----------|
-| cnpj_basico | 8 primeiros dígitos do CNPJ |
+| cnpj_basico | 8 primeiros caracteres do CNPJ (alfanuméricos 0-9/A-Z a partir de julho/2026) |
 | razao_social | Nome empresarial |
 | natureza_juridica | Código → naturezas_juridicas |
 | qualificacao_responsavel | Código → qualificacoes_socios |
@@ -57,9 +57,9 @@ erDiagram
 
 | Campo | Descrição |
 |-------|-----------|
-| cnpj_basico | 8 primeiros dígitos |
-| cnpj_ordem | 4 dígitos (0001=matriz) |
-| cnpj_dv | 2 dígitos verificadores |
+| cnpj_basico | 8 primeiros caracteres (alfanuméricos 0-9/A-Z) |
+| cnpj_ordem | 4 caracteres (alfanuméricos; 0001=matriz) |
+| cnpj_dv | 2 dígitos verificadores (numéricos) |
 | identificador_matriz_filial | 1=Matriz, 2=Filial |
 | nome_fantasia | Nome fantasia |
 | situacao_cadastral | Código da situação |
@@ -97,7 +97,7 @@ erDiagram
 | Campo | Descrição |
 |-------|-----------|
 | socio_id | UUID determinístico, PK. Hash blake2b de (cnpj_basico, identificador_de_socio, cnpj_cpf_do_socio, nome canonicalizado, data_entrada_sociedade). Sintético: não vem da RFB. |
-| cnpj_basico | 8 primeiros dígitos |
+| cnpj_basico | 8 primeiros caracteres (alfanuméricos 0-9/A-Z) |
 | identificador_de_socio | Tipo do sócio |
 | nome_socio | Nome (PF) ou Razão Social (PJ). Cru, não normalizado. |
 | cnpj_cpf_do_socio | CPF mascarado ou CNPJ. Não é único dentro de uma empresa (vide #78); use `socio_id` como chave. |
@@ -132,7 +132,7 @@ erDiagram
 
 | Campo | Descrição |
 |-------|-----------|
-| cnpj_basico | 8 primeiros dígitos |
+| cnpj_basico | 8 primeiros caracteres (alfanuméricos 0-9/A-Z) |
 | opcao_pelo_simples | S=Sim, N=Não, vazio=Outros |
 | data_opcao_simples | Data de opção |
 | data_exclusao_simples | Data de exclusão |

--- a/processor.py
+++ b/processor.py
@@ -391,26 +391,26 @@ _VALID_UFS = {
 # Format validation rules: (column, regex pattern, description)
 _FORMAT_RULES: dict[str, list[tuple[str, str, str]]] = {
     "EMPRECSV": [
-        ("cnpj_basico", r"^\d{8}$", "8 dígitos"),
+        ("cnpj_basico", r"^[0-9A-Z]{8}$", "8 caracteres alfanuméricos"),
         ("natureza_juridica", r"^\d{4}$", "4 dígitos"),
         ("qualificacao_responsavel", r"^\d{2}$", "2 dígitos"),
         ("porte", r"^(00|01|03|05)$", "00, 01, 03 ou 05"),
     ],
     "ESTABELE": [
-        ("cnpj_basico", r"^\d{8}$", "8 dígitos"),
-        ("cnpj_ordem", r"^\d{4}$", "4 dígitos"),
+        ("cnpj_basico", r"^[0-9A-Z]{8}$", "8 caracteres alfanuméricos"),
+        ("cnpj_ordem", r"^[0-9A-Z]{4}$", "4 caracteres alfanuméricos"),
         ("cnpj_dv", r"^\d{2}$", "2 dígitos"),
         ("situacao_cadastral", r"^(01|02|03|04|08)$", "01, 02, 03, 04 ou 08"),
         ("cep", r"^\d{8}$", "8 dígitos"),
         ("cnae_fiscal_principal", r"^\d{7}$", "7 dígitos"),
     ],
     "SOCIOCSV": [
-        ("cnpj_basico", r"^\d{8}$", "8 dígitos"),
+        ("cnpj_basico", r"^[0-9A-Z]{8}$", "8 caracteres alfanuméricos"),
         ("identificador_de_socio", r"^[123]$", "1, 2 ou 3"),
         ("faixa_etaria", r"^\d$", "1 dígito"),
     ],
     "SIMPLESCSV": [
-        ("cnpj_basico", r"^\d{8}$", "8 dígitos"),
+        ("cnpj_basico", r"^[0-9A-Z]{8}$", "8 caracteres alfanuméricos"),
         ("opcao_pelo_simples", r"^[SN]$", "S ou N"),
         ("opcao_pelo_mei", r"^[SN]$", "S ou N"),
     ],

--- a/recipes/postgres/empresas_busca_nome.sql
+++ b/recipes/postgres/empresas_busca_nome.sql
@@ -26,7 +26,7 @@
 --     does not enforce that invariant and the recipe does not assume it.
 --   - cnpj column is materialized as basico||ordem||dv, the same pattern
 --     as empresa_detalhe.sql. Lets consumers point-lookup by the
---     14-digit string without repeating the concatenation.
+--     14-character string without repeating the concatenation.
 --   - Source codes are preserved alongside denormalized descriptions
 --     (municipio_codigo + municipio_nome, cnae_fiscal_principal +
 --     cnae_descricao) so consumers can re-join the reference tables
@@ -72,7 +72,7 @@ ALTER TABLE empresas_busca_nome
     PRIMARY KEY (cnpj_basico, cnpj_ordem, cnpj_dv);
 
 -- Single-column index on the materialized cnpj for callers that look
--- up by the concatenated 14-digit string instead of the component tuple.
+-- up by the concatenated 14-character string instead of the component tuple.
 CREATE INDEX IF NOT EXISTS idx_empresas_busca_nome_cnpj
     ON empresas_busca_nome (cnpj);
 

--- a/scripts/data_quality_report.py
+++ b/scripts/data_quality_report.py
@@ -50,21 +50,29 @@ from typing import Optional
 import psycopg2
 
 # CNPJ check-digit algorithm (Brazilian RFB modulus-11 weighted sum).
-# Given 12 leading digits, compute DV1 with weights _W1, then DV2 with
-# weights _W2 over the 13 digits (12 + DV1). Rule: if (11 - sum%11) >= 10,
+# Given the 12-character stem, compute DV1 with weights _W1, then DV2 with
+# weights _W2 over the 13 values (12 + DV1). Rule: if (11 - sum%11) >= 10,
 # the digit is 0; otherwise (11 - sum%11).
+#
+# AIDEV-NOTE: cnpj-alphanumeric: from 2026-07 the stem (basico+ordem) may
+# contain A-Z as well as 0-9 (Receita Federal / Serpro). The published rule
+# values each character as ord(c) - 48, so '0'..'9' -> 0..9 and 'A'..'Z' ->
+# 17..42; the weights, modulus, and the two check digits stay numeric and
+# unchanged. Existing all-digit CNPJs are a strict subset and still validate.
 _W1 = (5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2)
 _W2 = (6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2)
+_CNPJ_STEM_CHARS = frozenset("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 
 def cnpj_expected_dv(first_12: str) -> str:
-    """Compute the 2-character check-digit string for a 12-digit CNPJ stem.
+    """Compute the 2-character check-digit string for a 12-character CNPJ stem.
 
-    Raises ValueError if input isn't exactly 12 digits.
+    The stem is the 8-char basico + 4-char ordem, each char in 0-9 or A-Z.
+    Raises ValueError if input isn't exactly 12 such characters.
     """
-    if len(first_12) != 12 or not first_12.isdigit():
-        raise ValueError(f"expected 12 digits, got {first_12!r}")
-    d = [int(c) for c in first_12]
+    if len(first_12) != 12 or any(c not in _CNPJ_STEM_CHARS for c in first_12):
+        raise ValueError(f"expected 12 alphanumeric (0-9, A-Z) chars, got {first_12!r}")
+    d = [ord(c) - 48 for c in first_12]
     s1 = sum(d[i] * _W1[i] for i in range(12))
     dv1 = 11 - (s1 % 11)
     if dv1 >= 10:

--- a/tests/test_data_quality_report.py
+++ b/tests/test_data_quality_report.py
@@ -46,9 +46,18 @@ class TestCnpjExpectedDV:
     def test_known_real_cnpjs(self, first_12, expected):
         assert cnpj_expected_dv(first_12) == expected
 
-    def test_rejects_non_digit(self):
+    def test_alphanumeric_official_example(self):
+        # Receita Federal's published alphanumeric example: 12.ABC.345/01DE-35.
+        # Stem 12ABC34501DE -> check digits 35 under the ord(c)-48 valuation.
+        assert cnpj_expected_dv("12ABC34501DE") == "35"
+
+    def test_rejects_lowercase_and_symbols(self):
+        # The stem alphabet is uppercase 0-9/A-Z only; lowercase and
+        # punctuation are not valid characters.
         with pytest.raises(ValueError):
-            cnpj_expected_dv("0000000000A1")
+            cnpj_expected_dv("0000000000a1")
+        with pytest.raises(ValueError):
+            cnpj_expected_dv("000000000.01")
 
     def test_rejects_wrong_length(self):
         with pytest.raises(ValueError):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -378,15 +378,42 @@ class TestSocioId:
 class TestValidate:
     """Test _validate function for format validation."""
 
-    def test_validate_cnpj_basico_format(self):
-        """Test that cnpj_basico must be exactly 8 digits."""
-        df = pl.DataFrame({"cnpj_basico": ["12345678", "1234", "ABCDEFGH", None]})
+    def test_validate_cnpj_basico_format(self, caplog):
+        """cnpj_basico is 8 uppercase alphanumeric chars (0-9, A-Z) from the
+        2026-07 alphanumeric CNPJ. Validation logs malformed values but keeps
+        raw data (no nullify)."""
+        df = pl.DataFrame({"cnpj_basico": ["12345678", "12ABC678", "ABCDEFGH", "1234", "abcd1234", None]})
 
-        result = _validate(df, "EMPRECSV")
+        with caplog.at_level("WARNING"):
+            result = _validate(df, "EMPRECSV")
 
-        # Validation logs but doesn't nullify format errors (keeps raw values)
+        # Numeric and uppercase-alphanumeric stems are valid and kept as-is.
         assert result["cnpj_basico"][0] == "12345678"
-        assert result["cnpj_basico"][1] == "1234"
+        assert result["cnpj_basico"][1] == "12ABC678"
+        assert result["cnpj_basico"][2] == "ABCDEFGH"
+        # Too-short "1234" and lowercase "abcd1234" are flagged but still kept.
+        assert "cnpj_basico: 2 invalid" in caplog.text
+        assert result["cnpj_basico"][3] == "1234"
+
+    def test_validate_cnpj_ordem_alphanumeric(self, caplog):
+        """cnpj_ordem is 4 uppercase alphanumeric chars; lowercase/short warn."""
+        df = pl.DataFrame({"cnpj_ordem": ["0001", "01DE", "abcd", "12", None]})
+
+        with caplog.at_level("WARNING"):
+            result = _validate(df, "ESTABELE")
+
+        assert result["cnpj_ordem"][1] == "01DE"
+        assert "cnpj_ordem: 2 invalid" in caplog.text
+
+    def test_validate_cnpj_dv_stays_numeric(self, caplog):
+        """cnpj_dv remains 2 numeric digits even under alphanumeric CNPJ;
+        an alphabetic dv is flagged."""
+        df = pl.DataFrame({"cnpj_dv": ["91", "3X", None]})
+
+        with caplog.at_level("WARNING"):
+            _validate(df, "ESTABELE")
+
+        assert "cnpj_dv: 1 invalid" in caplog.text
 
     def test_validate_situacao_cadastral(self):
         """Test that situacao_cadastral must be 01, 02, 03, 04, or 08."""


### PR DESCRIPTION
Receita Federal starts issuing alphanumeric CNPJs in July 2026 (e.g. 12.ABC.345/01DE-35). This lets the pipeline ingest and validate them while existing all-numeric CNPJs keep working unchanged.

What changes:
- `cnpj_basico` (8) and `cnpj_ordem` (4) validation moves from `^\d{N}$` to `^[0-9A-Z]{N}$`. `cnpj_dv` stays numeric (`^\d{2}$`).
- The data-quality check-digit routine values each character as `ord(c) - 48` (so 0-9 -> 0-9, A-Z -> 17-42) with the same mod-11 weights; the two check digits stay numeric.
- Schema and audit docs reflect the alphanumeric basico/ordem and numeric dv.

The valuation rule and the official example (`12ABC34501DE` -> `35`) are covered by tests; numeric CNPJs are a strict subset, so all prior cases still pass. Storage was already `VARCHAR`, so no migration is needed.