### PR TITLE
feat(recipes): add cnaes_hierarquia hierarchy recipe

### DIFF
--- a/docs/data-audit.md
+++ b/docs/data-audit.md
@@ -137,6 +137,18 @@ Dois campos vizinhos ficam fora desta receita de propósito:
 - **`situacao_especial`** já chega por extenso (texto legível, não código), então não há tabela de domínio a aplicar: fica como veio.
 - **`ente_federativo_responsavel`** é adiado: é o nome do ente público em texto livre, não um enum com tabela de código simples.
 
+## Hierarquia CNAE (receita `cnaes_hierarquia`)
+
+A tabela `cnaes` é plana (`codigo` de 7 dígitos, `descricao`), sem os níveis hierárquicos. A receita `recipes/postgres/cnaes_hierarquia.sql` deriva-os numa tabela por subclasse (grão = `cnaes.codigo`, mesma cardinalidade), sem alterar a tabela crua.
+
+`divisao`, `grupo` e `classe` são substrings do código, sem fonte externa:
+
+- `divisao` = `codigo[1..2]` (ex.: `0111301` → `01`)
+- `grupo` = `codigo[1..3]` (→ `011`)
+- `classe` = `codigo[1..4]` `-` `codigo[5]`, formato `DDDD-D` (→ `0111-3`)
+
+A **seção** (`A`–`U`) não é derivável do código: vem da correspondência divisão→seção do CNAE 2.3 (planilha oficial IBGE/CONCLA, ver Fontes oficiais). Uma divisão fora da lista oficial fica com `secao = NULL`; todo código real da Receita cai numa divisão válida. A tabela traz só os códigos e a `descricao` da subclasse — sem nomes de seção/divisão/grupo.
+
 ## Fontes oficiais
 
 Onde cada afirmação acima foi (ou não) verificada contra uma fonte oficial.
@@ -146,6 +158,7 @@ Onde cada afirmação acima foi (ou não) verificada contra uma fonte oficial.
 - **Forma do CEP (8 algarismos numéricos)** — Correios: ["O CEP é um conjunto numérico constituído de oito algarismos"](https://www.correios.com.br/enviar/precisa-de-ajuda/tudo-sobre-cep).
 - **Existência de um CEP específico** — a base de referência é o DNE/Correios. **Fora do escopo do núcleo do pipeline**: validar por chamada externa adicionaria dependência de autenticação, limite de uso e licenciamento, além de reduzir a reprodutibilidade da carga. Receitas ou ferramentas opcionais podem fazer essa checagem em amostra.
 - **Códigos de município e UF (geografia)** — IBGE é a fonte para enriquecimento geográfico (códigos de município, microrregião, mesorregião). IBGE **não é** fonte para validar CEP.
+- **Hierarquia CNAE (seção)** — IBGE/CONCLA. A correspondência divisão→seção do CNAE-Subclasses 2.3 (21 seções, 87 divisões) vem da planilha oficial [`CNAE_Subclasses_2_3_Estrutura_Detalhada.xlsx`](https://concla.ibge.gov.br/images/concla/documentacao/CNAE_Subclasses_2_3_Estrutura_Detalhada.xlsx), estabelecida pela Resolução CONCLA nº 2, de 19/11/2018 (DOU nº 222). Os 87 pares em `cnaes_hierarquia` foram derivados do parse dessa planilha.
 - **Layout dos dados abertos do CNPJ** — Receita Federal: [`cnpj-metadados.pdf`](https://www.gov.br/receitafederal/dados/cnpj-metadados.pdf). É um documento curto; não enumera valores válidos de `motivo`, `pais`, `uf` (além do que aparece em prosa), nem documenta sentinelas como `999999999999` em `capital_social` ou `'***000000**'` em `representante_legal`.
 - **Tabelas de domínio (motivo, país, qualificação)** — SERPRO, Base de Cadastros, que opera o cadastro CNPJ para a Receita Federal e publica as tabelas de domínio como CSV: [`bcadastros.serpro.gov.br/documentacao/dominios/pj/`](https://bcadastros.serpro.gov.br/documentacao/dominios/pj/) (`motivo_situacao_cadastral.csv`, `pais.csv`, `qualificacao_socio.csv`, `qualificacao_responsavel.csv`, `qualificacao_representante_legal.csv`). É a fonte das linhas suplementares de `reference_domains_enriched`. A tabela de países do Siscomex/Ministério da Economia ([`balanca.economia.gov.br/balanca/bd/tabelas/PAIS.csv`](https://balanca.economia.gov.br/balanca/bd/tabelas/PAIS.csv)) usa a mesma numeração e serve de checagem cruzada; nos casos em que o rótulo diverge (ex.: `150`), o SERPRO prevalece por ser a fonte do cadastro CNPJ.
 - **Tabelas de domínio (porte, situação cadastral, matriz/filial)** — mesmos diretórios do SERPRO: `porte_empresa.csv`, `situacao_cadastral.csv` e `indicador_matriz.csv`. Diferente das anteriores, o pacote mensal do CNPJ não traz CSV de domínio para esses três campos, então a CSV do SERPRO não é fonte suplementar, é a fonte única dos rótulos de `reference_domain_labels`. A única exceção é o `porte` `00` (Não informado), ausente da CSV do SERPRO e tirado do layout do CNPJ da Receita (`cnpj-metadados.pdf`).

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -14,6 +14,7 @@ A regra está em [../docs/post-processing.md](../docs/post-processing.md): o pip
 | `data_quality_flags` | [`postgres/data_quality_flags.sql`](postgres/data_quality_flags.sql) | Mede sinais de qualidade por estabelecimento, sem alterar valores. |
 | `estabelecimentos_clean` | [`postgres/estabelecimentos_clean.sql`](postgres/estabelecimentos_clean.sql) | Usa `data_quality_flags` para emitir pares cru/limpo de CEP e capital social. |
 | `cnae_secundaria_exploded` | [`postgres/cnae_secundaria_exploded.sql`](postgres/cnae_secundaria_exploded.sql) | Transforma `cnae_fiscal_secundaria` em uma tabela lateral: uma linha por CNAE secundário. |
+| `cnaes_hierarquia` | [`postgres/cnaes_hierarquia.sql`](postgres/cnaes_hierarquia.sql) | Tabela derivada por subclasse CNAE (grão = `cnaes.codigo`) com os níveis da hierarquia: `divisao`/`grupo`/`classe` (substrings do código) e `secao` (correspondência oficial IBGE/CONCLA CNAE 2.3, `NULL` para divisões desconhecidas). Não altera a tabela `cnaes`. |
 | `socios_quality_flags` | [`postgres/socios_quality_flags.sql`](postgres/socios_quality_flags.sql) | Mede sinais de qualidade por sócio, incluindo representante legal com valor de preenchimento e referências ausentes. |
 | `socios_clean` | [`postgres/socios_clean.sql`](postgres/socios_clean.sql) | Usa `socios_quality_flags` para emitir pares cru/limpo do trio do representante e de `faixa_etaria`. |
 | `socios_detalhe` | [`postgres/socios_detalhe.sql`](postgres/socios_detalhe.sql) | Tabela por sócio que junta `socios` com as descrições de qualificação e país (tabelas enriquecidas) e de `identificador_de_socio` e `faixa_etaria` (tabelas de rótulos). Preserva todos os códigos da fonte, sem mutação de valor. Equivale a `empresa_detalhe` no grão de sócio. Pré-requisitos: `reference_domains_enriched` e `reference_domain_labels`. |
@@ -40,6 +41,9 @@ psql "$DATABASE_URL" -f recipes/postgres/estabelecimentos_clean.sql
 
 # CNAEs secundários em tabela lateral
 psql "$DATABASE_URL" -f recipes/postgres/cnae_secundaria_exploded.sql
+
+# Hierarquia CNAE (seção/divisão/grupo/classe) por subclasse
+psql "$DATABASE_URL" -f recipes/postgres/cnaes_hierarquia.sql
 
 # Sinais de qualidade e camada limpa por sócio
 psql "$DATABASE_URL" -f recipes/postgres/socios_quality_flags.sql

--- a/recipes/postgres/cnaes_hierarquia.sql
+++ b/recipes/postgres/cnaes_hierarquia.sql
@@ -1,0 +1,64 @@
+-- recipes/postgres/cnaes_hierarquia.sql
+--
+-- recipeVersion: 1
+--
+-- Derived side table exposing the CNAE hierarchy (seção / divisão / grupo /
+-- classe) for every CNAE subclasse in the `cnaes` reference table. Lets
+-- consumers facet and group by hierarchy level without changing the flat
+-- reference table.
+--
+-- Apply after the pipeline finishes ingest:
+--     psql "$DATABASE_URL" -f recipes/postgres/cnaes_hierarquia.sql
+--
+-- Re-run after each monthly ingest to refresh.
+--
+-- Grain: one row per cnaes.codigo (same cardinality as the reference table).
+--
+-- Design choices (see docs/data-audit.md for the rationale):
+--   - divisao/grupo/classe are pure substrings of the 7-digit codigo, no
+--     external source: divisao = codigo[1..2] (01), grupo = codigo[1..3] (011),
+--     classe = codigo[1..4]-codigo[5] (0111-3, the DDDD-D form).
+--   - secao (A-U) is NOT derivable from the code: it maps to ranges of divisões
+--     set by IBGE. Source: the official IBGE/CONCLA "CNAE-Subclasses 2.3 -
+--     Estrutura Detalhada" workbook, Resolução CONCLA nº 2, de 19/11/2018
+--     (https://concla.ibge.gov.br/images/concla/documentacao/CNAE_Subclasses_2_3_Estrutura_Detalhada.xlsx).
+--     The 87 divisão->seção pairs in secao_por_divisao were derived by parsing
+--     that workbook (21 seções, 87 divisões; each divisão -> exactly one seção).
+--   - LEFT JOIN: a codigo whose divisão is not in the map (retired/unknown) is
+--     kept with secao = NULL, not dropped.
+--   - Carries cnaes.descricao for labels; does not add seção/divisão/grupo names
+--     (would need a second IBGE transcription, out of scope).
+
+DROP TABLE IF EXISTS cnaes_hierarquia;
+CREATE TABLE cnaes_hierarquia AS
+WITH secao_por_divisao (divisao, secao) AS (
+    VALUES
+        ('01', 'A'), ('02', 'A'), ('03', 'A'), ('05', 'B'), ('06', 'B'), ('07', 'B'), ('08', 'B'), ('09', 'B'),
+        ('10', 'C'), ('11', 'C'), ('12', 'C'), ('13', 'C'), ('14', 'C'), ('15', 'C'), ('16', 'C'), ('17', 'C'),
+        ('18', 'C'), ('19', 'C'), ('20', 'C'), ('21', 'C'), ('22', 'C'), ('23', 'C'), ('24', 'C'), ('25', 'C'),
+        ('26', 'C'), ('27', 'C'), ('28', 'C'), ('29', 'C'), ('30', 'C'), ('31', 'C'), ('32', 'C'), ('33', 'C'),
+        ('35', 'D'), ('36', 'E'), ('37', 'E'), ('38', 'E'), ('39', 'E'), ('41', 'F'), ('42', 'F'), ('43', 'F'),
+        ('45', 'G'), ('46', 'G'), ('47', 'G'), ('49', 'H'), ('50', 'H'), ('51', 'H'), ('52', 'H'), ('53', 'H'),
+        ('55', 'I'), ('56', 'I'), ('58', 'J'), ('59', 'J'), ('60', 'J'), ('61', 'J'), ('62', 'J'), ('63', 'J'),
+        ('64', 'K'), ('65', 'K'), ('66', 'K'), ('68', 'L'), ('69', 'M'), ('70', 'M'), ('71', 'M'), ('72', 'M'),
+        ('73', 'M'), ('74', 'M'), ('75', 'M'), ('77', 'N'), ('78', 'N'), ('79', 'N'), ('80', 'N'), ('81', 'N'),
+        ('82', 'N'), ('84', 'O'), ('85', 'P'), ('86', 'Q'), ('87', 'Q'), ('88', 'Q'), ('90', 'R'), ('91', 'R'),
+        ('92', 'R'), ('93', 'R'), ('94', 'S'), ('95', 'S'), ('96', 'S'), ('97', 'T'), ('99', 'U')
+)
+SELECT
+    c.codigo,
+    c.descricao,
+    m.secao,
+    substr(c.codigo, 1, 2) AS divisao,
+    substr(c.codigo, 1, 3) AS grupo,
+    substr(c.codigo, 1, 4) || '-' || substr(c.codigo, 5, 1) AS classe
+FROM cnaes c
+LEFT JOIN secao_por_divisao m ON m.divisao = substr(c.codigo, 1, 2);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cnaes_hierarquia_codigo ON cnaes_hierarquia (codigo);
+CREATE INDEX IF NOT EXISTS idx_cnaes_hierarquia_secao ON cnaes_hierarquia (secao);
+CREATE INDEX IF NOT EXISTS idx_cnaes_hierarquia_divisao ON cnaes_hierarquia (divisao);
+CREATE INDEX IF NOT EXISTS idx_cnaes_hierarquia_grupo ON cnaes_hierarquia (grupo);
+CREATE INDEX IF NOT EXISTS idx_cnaes_hierarquia_classe ON cnaes_hierarquia (classe);
+
+ANALYZE cnaes_hierarquia;

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2093,3 +2093,136 @@ class TestDataQualityReportMeasurements:
 
         # restore for any later test that expects them
         self._ensure_enriched(test_db)
+
+
+class TestRecipeCnaesHierarquia:
+    """Apply recipes/postgres/cnaes_hierarquia.sql against the fixture-loaded
+    database and verify the derived CNAE hierarchy table.
+
+    Depends on test_db being populated by TestFullPipeline (module-scoped
+    fixture; pytest runs classes in file order, so cnaes is already loaded).
+    """
+
+    RECIPE_PATH = Path(__file__).parent.parent / "recipes" / "postgres" / "cnaes_hierarquia.sql"
+
+    # Independent restatement of the official IBGE/CONCLA CNAE-Subclasses 2.3
+    # divisão->seção correspondence (Resolução CONCLA nº 2, de 19/11/2018),
+    # kept separate from the recipe's 87-pair VALUES as a double-entry check:
+    # each seção mapped to the inclusive range(s) of 2-digit divisões it owns.
+    _SECTION_RANGES = {
+        "A": [(1, 3)],
+        "B": [(5, 9)],
+        "C": [(10, 33)],
+        "D": [(35, 35)],
+        "E": [(36, 39)],
+        "F": [(41, 43)],
+        "G": [(45, 47)],
+        "H": [(49, 53)],
+        "I": [(55, 56)],
+        "J": [(58, 63)],
+        "K": [(64, 66)],
+        "L": [(68, 68)],
+        "M": [(69, 75)],
+        "N": [(77, 82)],
+        "O": [(84, 84)],
+        "P": [(85, 85)],
+        "Q": [(86, 88)],
+        "R": [(90, 93)],
+        "S": [(94, 96)],
+        "T": [(97, 97)],
+        "U": [(99, 99)],
+    }
+
+    @classmethod
+    def _expected_secao(cls, divisao: str) -> str | None:
+        n = int(divisao)
+        for secao, ranges in cls._SECTION_RANGES.items():
+            if any(lo <= n <= hi for lo, hi in ranges):
+                return secao
+        return None
+
+    def _apply(self, test_db):
+        sql = self.RECIPE_PATH.read_text()
+        with test_db.conn.cursor() as cur:
+            cur.execute(sql)
+        test_db.conn.commit()
+
+    def test_recipe_executes(self, test_db):
+        """The recipe SQL should parse and execute, creating the table."""
+        self._apply(test_db)
+        with test_db.conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM information_schema.tables WHERE table_name = 'cnaes_hierarquia'")
+            assert cur.fetchone() is not None, "cnaes_hierarquia table not created"
+
+    def test_row_count_matches_cnaes(self, test_db):
+        """Grain is one row per cnaes.codigo - same cardinality as cnaes."""
+        self._apply(test_db)
+        expected = _count_rows(test_db, "cnaes")
+        got = _count_rows(test_db, "cnaes_hierarquia")
+        assert got > 0, "cnaes_hierarquia is empty (was cnaes loaded?)"
+        assert got == expected, f"cnaes_hierarquia ({got}) != cnaes ({expected})"
+
+    def test_known_example(self, test_db):
+        """Issue #94 contract: 0111301 -> divisao 01, grupo 011, classe 0111-3, secao A."""
+        self._apply(test_db)
+        with test_db.conn.cursor() as cur:
+            cur.execute(
+                "SELECT divisao, grupo, classe, secao FROM cnaes_hierarquia WHERE codigo = %s",
+                ("0111301",),
+            )
+            row = cur.fetchone()
+        assert row is not None, "0111301 missing from cnaes_hierarquia"
+        assert row == ("01", "011", "0111-3", "A"), f"unexpected derivation for 0111301: {row}"
+
+    def test_substring_fields_match_codigo(self, test_db):
+        """divisao/grupo/classe are pure substrings of the 7-digit codigo."""
+        self._apply(test_db)
+        with test_db.conn.cursor() as cur:
+            cur.execute("""
+                SELECT COUNT(*) FROM cnaes_hierarquia
+                WHERE divisao <> left(codigo, 2)
+                   OR grupo <> left(codigo, 3)
+                   OR classe <> left(codigo, 4) || '-' || substr(codigo, 5, 1)
+            """)
+            bad = cur.fetchone()[0]
+        assert bad == 0, f"{bad} rows have substring fields inconsistent with codigo"
+
+    def test_secao_never_null_for_real_codes(self, test_db):
+        """Every real RFB CNAE code belongs to an official divisão, so secao
+        must be non-NULL for all fixture rows."""
+        self._apply(test_db)
+        with test_db.conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM cnaes_hierarquia WHERE secao IS NULL")
+            nulls = cur.fetchone()[0]
+        assert nulls == 0, f"{nulls} rows have NULL secao - a divisão is missing from the official map"
+
+    def test_secao_matches_official_map(self, test_db):
+        """Every row's secao must equal the seção the official IBGE CNAE 2.3
+        divisão->seção correspondence assigns to its divisão. Checked against an
+        independent restatement of the mapping (not imported from the recipe)."""
+        self._apply(test_db)
+        with test_db.conn.cursor() as cur:
+            cur.execute("SELECT codigo, divisao, secao FROM cnaes_hierarquia")
+            rows = cur.fetchall()
+        mismatches = [
+            (codigo, divisao, secao, self._expected_secao(divisao))
+            for codigo, divisao, secao in rows
+            if secao != self._expected_secao(divisao)
+        ]
+        assert not mismatches, f"secao mismatches vs official map: {mismatches[:10]}"
+
+    def test_codigo_is_unique(self, test_db):
+        """codigo is the natural key - one row per subclasse."""
+        self._apply(test_db)
+        with test_db.conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*), COUNT(DISTINCT codigo) FROM cnaes_hierarquia")
+            total, distinct = cur.fetchone()
+        assert total == distinct, f"codigo not unique: {total} rows, {distinct} distinct"
+
+    def test_idempotent(self, test_db):
+        """Re-running drops+recreates without error and yields the same count."""
+        self._apply(test_db)
+        before = _count_rows(test_db, "cnaes_hierarquia")
+        self._apply(test_db)
+        after = _count_rows(test_db, "cnaes_hierarquia")
+        assert before == after, f"row count changed on re-run: {before} -> {after}"


### PR DESCRIPTION
Adds an optional pure-SQL recipe that derives the CNAE hierarchy (seção/divisão/grupo/classe) for every row of the flat `cnaes` reference table, so consumers can facet and group by hierarchy without changing the reference table.

- `divisao`/`grupo`/`classe` are deterministic substrings of the 7-digit code (`classe` in `DDDD-D` form).
- `secao` (A–U) is not derivable from the number: it comes from the official IBGE/CONCLA CNAE-Subclasses 2.3 divisão→seção correspondence (Resolução CONCLA nº 2, de 19/11/2018), embedded as an 87-pair map. Unknown/retired divisão → NULL, no row dropped.
- Additive and idempotent; does not touch the raw `cnaes` table. Docs and integration tests included — `secao` is validated for every fixture row against an independent restatement of the official map.

Closes #94
