### PR TITLE
feat(downloader): degrade concurrency when the server stalls parallel streams

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,6 +24,7 @@ class Config:
     # as the between-bytes read timeout so silent streams resume quickly.
     read_timeout: int = 300
     stall_timeout: int = 30
+    stall_degrade_threshold: int = 3
     progress_log_interval: int = 30
     keep_files: bool = False
     loading_strategy: str = "upsert"  # "upsert" or "replace"
@@ -53,6 +54,7 @@ class Config:
             connect_timeout=int(os.getenv("CONNECT_TIMEOUT", "30")),
             read_timeout=int(os.getenv("READ_TIMEOUT", "300")),
             stall_timeout=int(os.getenv("STALL_TIMEOUT", "30")),
+            stall_degrade_threshold=int(os.getenv("STALL_DEGRADE_THRESHOLD", "3")),
             progress_log_interval=int(os.getenv("PROGRESS_LOG_INTERVAL", "30")),
             keep_files=os.getenv("KEEP_DOWNLOADED_FILES", "false").lower() == "true",
             loading_strategy=os.getenv("LOADING_STRATEGY", "upsert").lower(),

--- a/downloader.py
+++ b/downloader.py
@@ -5,8 +5,10 @@ import os
 import re
 import time
 import zipfile
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass
 from pathlib import Path
+from threading import Lock
 from time import monotonic
 from typing import Callable, Iterator, List, Mapping, Tuple
 from xml.etree import ElementTree
@@ -54,6 +56,67 @@ class DownloadIncompleteError(RuntimeError):
 
 class DownloadStalledError(DownloadIncompleteError):
     """Raised when a download stream stops yielding bytes past the stall timeout."""
+
+
+@dataclass(frozen=True)
+class ConcurrencyDegradation:
+    """A one-way adaptive concurrency change triggered by cumulative stalls."""
+
+    stall_count: int
+    previous_concurrency: int
+    new_concurrency: int
+
+
+class AdaptiveDownloadConcurrency:
+    """Track stream stalls and reduce download concurrency for the current run."""
+
+    def __init__(self, initial_concurrency: int, stall_degrade_threshold: int):
+        self._current_concurrency = initial_concurrency
+        self._stall_degrade_threshold = max(1, stall_degrade_threshold)
+        self._next_degrade_at = self._stall_degrade_threshold
+        self._stall_count = 0
+        self._lock = Lock()
+
+    @property
+    def current_concurrency(self) -> int:
+        with self._lock:
+            return self._current_concurrency
+
+    @property
+    def stall_count(self) -> int:
+        with self._lock:
+            return self._stall_count
+
+    def record_stall(self) -> ConcurrencyDegradation | None:
+        degradation: ConcurrencyDegradation | None = None
+        with self._lock:
+            self._stall_count += 1
+            if self._stall_count >= self._next_degrade_at:
+                new_concurrency = self._degraded_concurrency(self._current_concurrency)
+                if new_concurrency < self._current_concurrency:
+                    degradation = ConcurrencyDegradation(
+                        stall_count=self._stall_count,
+                        previous_concurrency=self._current_concurrency,
+                        new_concurrency=new_concurrency,
+                    )
+                    self._current_concurrency = new_concurrency
+                self._next_degrade_at += self._stall_degrade_threshold
+
+        if degradation is not None:
+            logger.warning(
+                f"{degradation.stall_count} stalls at concurrency {degradation.previous_concurrency}, "
+                f"degrading to {degradation.new_concurrency} for the rest of the run"
+            )
+
+        return degradation
+
+    @staticmethod
+    def _degraded_concurrency(current_concurrency: int) -> int:
+        if current_concurrency > 2:
+            return 2
+        if current_concurrency > 1:
+            return 1
+        return current_concurrency
 
 
 class Downloader:
@@ -133,30 +196,66 @@ class Downloader:
         # Split into reference and data files
         reference_files = [f for f in files if f in REFERENCE_FILES]
         data_files = [f for f in files if f not in REFERENCE_FILES]
+        adaptive_concurrency = AdaptiveDownloadConcurrency(
+            self.config.download_workers,
+            self.config.stall_degrade_threshold,
+        )
 
         # Process reference files first (sequentially)
         for filename in reference_files:
-            for csv_path in self._download_and_extract(directory, filename):
+            for csv_path in self._download_and_extract(directory, filename, adaptive_concurrency.record_stall):
                 yield csv_path, filename
 
         # Process data files in parallel
         if data_files:
-            yield from self._download_parallel(directory, data_files)
+            yield from self._download_parallel(directory, data_files, adaptive_concurrency)
 
-    def _download_parallel(self, directory: str, files: List[str]) -> Iterator[Tuple[Path, str]]:
+    def _download_parallel(
+        self,
+        directory: str,
+        files: List[str],
+        adaptive_concurrency: AdaptiveDownloadConcurrency,
+    ) -> Iterator[Tuple[Path, str]]:
         """Download data files in parallel using ThreadPoolExecutor."""
         with ThreadPoolExecutor(max_workers=self.config.download_workers) as executor:
-            future_to_filename = {
-                executor.submit(self._download_and_extract, directory, filename): filename for filename in files
-            }
+            next_file_index = 0
+            future_to_filename: dict[Future[List[Path]], str] = {}
 
-            for future in as_completed(future_to_filename):
-                filename = future_to_filename[future]
-                extracted_files = future.result()
-                for csv_path in extracted_files:
-                    yield csv_path, filename
+            def submit_until_limit() -> None:
+                nonlocal next_file_index
+                while (
+                    next_file_index < len(files) and len(future_to_filename) < adaptive_concurrency.current_concurrency
+                ):
+                    filename = files[next_file_index]
+                    next_file_index += 1
+                    future = executor.submit(
+                        self._download_and_extract,
+                        directory,
+                        filename,
+                        adaptive_concurrency.record_stall,
+                    )
+                    future_to_filename[future] = filename
 
-    def _download_and_extract(self, directory: str, filename: str) -> List[Path]:
+            submit_until_limit()
+            while future_to_filename:
+                completed_futures, _ = wait(future_to_filename, return_when=FIRST_COMPLETED)
+                completed_downloads: list[tuple[str, List[Path]]] = []
+                for future in completed_futures:
+                    filename = future_to_filename.pop(future)
+                    extracted_files = future.result()
+                    completed_downloads.append((filename, extracted_files))
+                submit_until_limit()
+
+                for filename, extracted_files in completed_downloads:
+                    for csv_path in extracted_files:
+                        yield csv_path, filename
+
+    def _download_and_extract(
+        self,
+        directory: str,
+        filename: str,
+        record_stall: Callable[[], ConcurrencyDegradation | None] | None = None,
+    ) -> List[Path]:
         """Download a single ZIP file and extract CSV files."""
         url = f"{self.config.base_url}/{directory}/{filename}"
         zip_path = self.temp_path / filename
@@ -168,7 +267,7 @@ class Downloader:
         if self.config.keep_files and zip_path.exists() and self._cached_zip_is_valid(zip_path):
             log(f"Using cached: {filename}")
         else:
-            self._download_zip(url, directory, filename, zip_path, log)
+            self._download_zip(url, directory, filename, zip_path, log, record_stall)
 
         # Extract CSV files
         extracted_files = []
@@ -192,7 +291,13 @@ class Downloader:
         return extracted_files
 
     def _download_zip(
-        self, url: str, directory: str, filename: str, zip_path: Path, log: Callable[[str], None]
+        self,
+        url: str,
+        directory: str,
+        filename: str,
+        zip_path: Path,
+        log: Callable[[str], None],
+        record_stall: Callable[[], ConcurrencyDegradation | None] | None,
     ) -> None:
         """Download a ZIP through a resumable .part file and validate it."""
         # The .part name carries the source directory (month): CNPJ file names
@@ -213,7 +318,10 @@ class Downloader:
                 if zip_path.exists():
                     zip_path.unlink()
 
-                if not isinstance(e, DownloadStalledError):
+                if isinstance(e, DownloadStalledError):
+                    if record_stall is not None:
+                        record_stall()
+                else:
                     logger.warning(f"Download attempt {attempt + 1} failed: {e}")
                 if attempt < self.config.retry_attempts - 1:
                     time.sleep(self.config.retry_delay)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,7 @@ class TestFromEnv:
         assert cfg.connect_timeout == 30
         assert cfg.read_timeout == 300
         assert cfg.stall_timeout == 30
+        assert cfg.stall_degrade_threshold == 3
         assert cfg.progress_log_interval == 30
         assert cfg.keep_files is False
         assert cfg.loading_strategy == "upsert"
@@ -42,6 +43,7 @@ class TestFromEnv:
             "PROCESS_WORKERS": "4",
             "RETRY_ATTEMPTS": "5",
             "STALL_TIMEOUT": "12",
+            "STALL_DEGRADE_THRESHOLD": "2",
             "PROGRESS_LOG_INTERVAL": "45",
         }
         with patch.dict("os.environ", env, clear=True):
@@ -53,6 +55,7 @@ class TestFromEnv:
         assert cfg.process_workers == 4
         assert cfg.retry_attempts == 5
         assert cfg.stall_timeout == 12
+        assert cfg.stall_degrade_threshold == 2
         assert cfg.progress_log_interval == 45
 
     def test_int_coercion(self):
@@ -62,6 +65,7 @@ class TestFromEnv:
             "CONNECT_TIMEOUT": "60",
             "READ_TIMEOUT": "120",
             "STALL_TIMEOUT": "15",
+            "STALL_DEGRADE_THRESHOLD": "4",
             "PROGRESS_LOG_INTERVAL": "0",
         }
         with patch.dict("os.environ", env, clear=True):
@@ -71,6 +75,7 @@ class TestFromEnv:
         assert cfg.connect_timeout == 60
         assert cfg.read_timeout == 120
         assert cfg.stall_timeout == 15
+        assert cfg.stall_degrade_threshold == 4
         assert cfg.progress_log_interval == 0
 
     def test_invalid_int_raises(self):

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -8,7 +8,13 @@ import pytest
 import requests
 
 from config import Config
-from downloader import CNPJ_FILE_PATTERNS, Downloader, DownloadIncompleteError, DownloadStalledError
+from downloader import (
+    CNPJ_FILE_PATTERNS,
+    AdaptiveDownloadConcurrency,
+    Downloader,
+    DownloadIncompleteError,
+    DownloadStalledError,
+)
 
 
 def _webdav_xml(entries: list[str]) -> bytes:
@@ -500,6 +506,106 @@ class TestDownloadFiles:
 
             with pytest.raises(requests.exceptions.Timeout):
                 list(downloader.download_files("2024-03", ["Cnaes.zip"]))
+
+
+class TestAdaptiveDownloadConcurrency:
+    """Test adaptive concurrency degradation decisions."""
+
+    def test_degrades_from_four_to_two_to_one_at_threshold_crossings(self, caplog):
+        caplog.set_level(logging.WARNING, logger="downloader")
+        adaptive_concurrency = AdaptiveDownloadConcurrency(initial_concurrency=4, stall_degrade_threshold=2)
+
+        assert adaptive_concurrency.current_concurrency == 4
+        assert adaptive_concurrency.record_stall() is None
+        assert adaptive_concurrency.current_concurrency == 4
+
+        first_degradation = adaptive_concurrency.record_stall()
+        assert first_degradation is not None
+        assert first_degradation.previous_concurrency == 4
+        assert first_degradation.new_concurrency == 2
+        assert adaptive_concurrency.current_concurrency == 2
+
+        assert adaptive_concurrency.record_stall() is None
+        assert adaptive_concurrency.current_concurrency == 2
+
+        second_degradation = adaptive_concurrency.record_stall()
+        assert second_degradation is not None
+        assert second_degradation.previous_concurrency == 2
+        assert second_degradation.new_concurrency == 1
+        assert adaptive_concurrency.current_concurrency == 1
+
+        assert "2 stalls at concurrency 4, degrading to 2 for the rest of the run" in caplog.text
+        assert "4 stalls at concurrency 2, degrading to 1 for the rest of the run" in caplog.text
+
+    def test_degradation_never_scales_back_up(self):
+        adaptive_concurrency = AdaptiveDownloadConcurrency(initial_concurrency=4, stall_degrade_threshold=1)
+
+        for _ in range(5):
+            adaptive_concurrency.record_stall()
+
+        assert adaptive_concurrency.current_concurrency == 1
+        assert adaptive_concurrency.stall_count == 5
+
+    def test_stalls_below_threshold_leave_concurrency_unchanged(self, caplog):
+        caplog.set_level(logging.WARNING, logger="downloader")
+        adaptive_concurrency = AdaptiveDownloadConcurrency(initial_concurrency=4, stall_degrade_threshold=3)
+
+        adaptive_concurrency.record_stall()
+        adaptive_concurrency.record_stall()
+
+        assert adaptive_concurrency.current_concurrency == 4
+        assert "degrading" not in caplog.text
+
+
+class TestAdaptiveDownloadIntegration:
+    """Test adaptive degradation through the resumable download path."""
+
+    def test_stalled_file_resumes_and_completes_after_degrading_to_one(self, downloader, tmp_path, monkeypatch, caplog):
+        downloader.config.download_workers = 4
+        downloader.config.stall_degrade_threshold = 1
+        downloader.config.retry_attempts = 3
+        downloader.config.retry_delay = 0
+        downloader.config.keep_files = True
+        monkeypatch.setenv("TQDM_DISABLE", "1")
+        caplog.set_level(logging.WARNING, logger="downloader")
+        zip_content = _create_test_zip(tmp_path, {"EMPRECSV.D51213": "0111301;Test"})
+        first_split = len(zip_content) // 3
+        second_split = first_split * 2
+        scripted_get = _ScriptedGet(
+            [
+                _ScriptedResponse(
+                    chunks=[zip_content[:first_split], requests.exceptions.Timeout("stalled stream")],
+                    headers={"content-length": str(len(zip_content))},
+                ),
+                _ScriptedResponse(
+                    chunks=[zip_content[first_split:second_split], requests.exceptions.Timeout("stalled stream")],
+                    headers={
+                        "content-range": f"bytes {first_split}-{len(zip_content) - 1}/{len(zip_content)}",
+                        "content-length": str(len(zip_content) - first_split),
+                    },
+                    status_code=206,
+                ),
+                _ScriptedResponse(
+                    chunks=[zip_content[second_split:]],
+                    headers={
+                        "content-range": f"bytes {second_split}-{len(zip_content) - 1}/{len(zip_content)}",
+                        "content-length": str(len(zip_content) - second_split),
+                    },
+                    status_code=206,
+                ),
+            ]
+        )
+        monkeypatch.setattr(requests, "get", scripted_get)
+
+        result = list(downloader.download_files("2024-03", ["Empresas0.zip"]))
+
+        assert len(result) == 1
+        assert result[0][1] == "Empresas0.zip"
+        assert scripted_get.calls[0]["headers"] == {"Accept-Encoding": "identity"}
+        assert scripted_get.calls[1]["headers"] == {"Accept-Encoding": "identity", "Range": f"bytes={first_split}-"}
+        assert scripted_get.calls[2]["headers"] == {"Accept-Encoding": "identity", "Range": f"bytes={second_split}-"}
+        assert "1 stalls at concurrency 4, degrading to 2 for the rest of the run" in caplog.text
+        assert "2 stalls at concurrency 2, degrading to 1 for the rest of the run" in caplog.text
 
 
 class TestCleanup:


### PR DESCRIPTION
Receita's server serves single streams at full speed but stalls concurrent streams from one client after a few MB - retrying at the same concurrency just re-triggers the stall. The downloader now notices systemic stalling and adapts instead of fighting it.

- A run-wide stall counter (fed by every DownloadStalledError, including ones resume recovered from) degrades the effective concurrency 4 -> 2 -> 1 for the remainder of the run once STALL_DEGRADE_THRESHOLD (default 3) is crossed at each level
- Degradation is one-way per run and only affects files not yet started; per-file Range resume from #96/#97 is untouched
- Each degradation is logged so operators can see the server's behavior in the run log
- Stacked on #97 (stall watchdog); merge #96 then #97 first

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds adaptive download concurrency to avoid repeated stalls when the server throttles parallel streams. The downloader now detects systemic stalls and reduces concurrency (4→2→1) while keeping per-file range resume intact.

- **New Features**
  - Added AdaptiveDownloadConcurrency with a run-wide stall counter; degrades concurrency 4 → 2 → 1 at each multiple of `stall_degrade_threshold` (default 3 via `STALL_DEGRADE_THRESHOLD`).
  - Counts every `DownloadStalledError`, even if the stream later resumes.
  - Degradation is one-way for the run and only applies to files not yet started; range-resume behavior is unchanged.
  - Parallel scheduler limits active tasks to the current adaptive limit; each degradation is logged at WARN.

<sup>Written for commit 2a00b30923822c2e02987c07493f5d582a3c7602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/caiopizzol/cnpj-data-pipeline/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

