### PR TITLE
fix(downloader): typed read-timeout detection and stale-partial pruning

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -14,6 +14,7 @@ from typing import Callable, Iterator, List, Mapping, Tuple
 from xml.etree import ElementTree
 
 import requests
+import urllib3.exceptions
 from tqdm import tqdm
 
 from config import Config
@@ -178,6 +179,7 @@ class Downloader:
 
     def download_file(self, directory: str, filename: str) -> List[Path]:
         """Download and extract a single ZIP file. Returns list of extracted CSV paths."""
+        self._prune_stale_partials(directory)
         return self._download_and_extract(directory, filename)
 
     def download_files(self, directory: str, files: List[str]) -> Iterator[Tuple[Path, str]]:
@@ -192,6 +194,8 @@ class Downloader:
         """
         if not files:
             return
+
+        self._prune_stale_partials(directory)
 
         # Split into reference and data files
         reference_files = [f for f in files if f in REFERENCE_FILES]
@@ -290,6 +294,22 @@ class Downloader:
 
         return extracted_files
 
+    @staticmethod
+    def _directory_slug(directory: str) -> str:
+        return re.sub(r"[^A-Za-z0-9_-]", "_", directory) or "root"
+
+    def _prune_stale_partials(self, directory: str) -> None:
+        """Delete .part resume files left over from other source directories.
+        cleanup() deliberately preserves partials so a failed run can resume,
+        but a partial from another month can never be resumed (its slug will
+        never match) - without pruning, every failed historical attempt would
+        retain multi-GB files forever."""
+        suffix = f".{self._directory_slug(directory)}.part"
+        for part_file in self.temp_path.glob("*.part"):
+            if not part_file.name.endswith(suffix):
+                logger.info(f"Removing stale partial from another source directory: {part_file.name}")
+                part_file.unlink(missing_ok=True)
+
     def _download_zip(
         self,
         url: str,
@@ -303,8 +323,7 @@ class Downloader:
         # The .part name carries the source directory (month): CNPJ file names
         # repeat across monthly directories, and resuming (or 416-finalizing)
         # a partial that belongs to another month would corrupt the dataset.
-        directory_slug = re.sub(r"[^A-Za-z0-9_-]", "_", directory) or "root"
-        part_path = zip_path.with_name(f"{zip_path.name}.{directory_slug}.part")
+        part_path = zip_path.with_name(f"{zip_path.name}.{self._directory_slug(directory)}.part")
 
         if zip_path.exists():
             zip_path.unlink()
@@ -439,6 +458,23 @@ class Downloader:
 
     @staticmethod
     def _is_read_timeout(exc: requests.exceptions.ConnectionError) -> bool:
+        """True when a ConnectionError is a read timeout in disguise.
+        requests' iter_content re-raises urllib3's ReadTimeoutError as
+        ConnectionError(e), so the typed evidence lives in the args and the
+        exception chain; the string match stays as a last-resort fallback."""
+        seen: set[int] = set()
+        stack: list[BaseException] = [exc]
+        while stack:
+            current = stack.pop()
+            if id(current) in seen:
+                continue
+            seen.add(id(current))
+            if isinstance(current, (urllib3.exceptions.ReadTimeoutError, TimeoutError)):
+                return True
+            stack.extend(arg for arg in current.args if isinstance(arg, BaseException))
+            for linked in (current.__cause__, current.__context__):
+                if linked is not None:
+                    stack.append(linked)
         return "read timed out" in str(exc).lower()
 
     def _prepare_download_response(

--- a/downloader.py
+++ b/downloader.py
@@ -305,7 +305,9 @@ class Downloader:
         never match) - without pruning, every failed historical attempt would
         retain multi-GB files forever."""
         suffix = f".{self._directory_slug(directory)}.part"
-        for part_file in self.temp_path.glob("*.part"):
+        # Only touch downloader-owned resume files ({name}.zip.{slug}.part):
+        # TEMP_DIR may be shared, and unrelated *.part files are not ours to delete.
+        for part_file in self.temp_path.glob("*.zip.*.part"):
             if not part_file.name.endswith(suffix):
                 logger.info(f"Removing stale partial from another source directory: {part_file.name}")
                 part_file.unlink(missing_ok=True)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1203,6 +1203,8 @@ class TestStalePartialPruning:
         stale.write_bytes(b"stale month")
         same_month_other_file = downloader.temp_path / "Empresas0.zip.2026-06.part"
         same_month_other_file.write_bytes(b"current month")
+        unrelated = downloader.temp_path / "not-ours.part"
+        unrelated.write_bytes(b"someone else's file")
 
         zip_content = _create_test_zip(tmp_path, {"CNAECSV.D51213": "0111301;Test"})
         scripted_get = _ScriptedGet(
@@ -1214,6 +1216,7 @@ class TestStalePartialPruning:
 
         assert not stale.exists()
         assert same_month_other_file.exists()
+        assert unrelated.exists()
 
     def test_download_files_prunes_partials_from_other_directories(self, downloader, tmp_path, monkeypatch):
         stale = downloader.temp_path / "Socios9.zip.2026-05.part"

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+import urllib3.exceptions
 
 from config import Config
 from downloader import (
@@ -1172,3 +1173,59 @@ class TestResumeEdgeCases:
 
         with pytest.raises(requests.exceptions.ConnectionError, match="reset by peer"):
             downloader._download_and_extract("2024-03", "Cnaes.zip")
+
+
+class TestReadTimeoutDetection:
+    def test_typed_read_timeout_in_args(self):
+        inner = urllib3.exceptions.ReadTimeoutError(None, "/url", "the socket gave up")
+        assert Downloader._is_read_timeout(requests.exceptions.ConnectionError(inner))
+
+    def test_typed_read_timeout_in_cause_chain(self):
+        exc = requests.exceptions.ConnectionError("proxy failure")
+        exc.__cause__ = TimeoutError("no matching phrase here")
+        assert Downloader._is_read_timeout(exc)
+
+    def test_string_fallback_still_matches(self):
+        assert Downloader._is_read_timeout(requests.exceptions.ConnectionError("Read timed out."))
+
+    def test_unrelated_connection_error_is_not_a_timeout(self):
+        assert not Downloader._is_read_timeout(requests.exceptions.ConnectionError("Connection reset by peer"))
+
+    def test_self_referencing_chain_terminates(self):
+        exc = requests.exceptions.ConnectionError("reset")
+        exc.__context__ = exc
+        assert not Downloader._is_read_timeout(exc)
+
+
+class TestStalePartialPruning:
+    def test_download_file_prunes_partials_from_other_directories(self, downloader, tmp_path, monkeypatch):
+        stale = downloader.temp_path / "Empresas0.zip.2026-05.part"
+        stale.write_bytes(b"stale month")
+        same_month_other_file = downloader.temp_path / "Empresas0.zip.2026-06.part"
+        same_month_other_file.write_bytes(b"current month")
+
+        zip_content = _create_test_zip(tmp_path, {"CNAECSV.D51213": "0111301;Test"})
+        scripted_get = _ScriptedGet(
+            [_ScriptedResponse(chunks=[zip_content], headers={"content-length": str(len(zip_content))})]
+        )
+        monkeypatch.setattr(requests, "get", scripted_get)
+
+        downloader.download_file("2026-06", "Cnaes.zip")
+
+        assert not stale.exists()
+        assert same_month_other_file.exists()
+
+    def test_download_files_prunes_partials_from_other_directories(self, downloader, tmp_path, monkeypatch):
+        stale = downloader.temp_path / "Socios9.zip.2026-05.part"
+        stale.write_bytes(b"stale month")
+
+        zip_content = _create_test_zip(tmp_path, {"CNAECSV.D51213": "0111301;Test"})
+        scripted_get = _ScriptedGet(
+            [_ScriptedResponse(chunks=[zip_content], headers={"content-length": str(len(zip_content))})]
+        )
+        monkeypatch.setattr(requests, "get", scripted_get)
+
+        results = list(downloader.download_files("2026-06", ["Cnaes.zip"]))
+
+        assert len(results) == 1
+        assert not stale.exists()


### PR DESCRIPTION
Two follow-ups to the download-hardening series (#96–#98).

Mid-stream read timeouts were recognized by string-matching "read timed out" on the ConnectionError. requests re-raises urllib3's ReadTimeoutError as ConnectionError(e), so the typed evidence is right there in the exception args and chain; the detector now walks both (cycle-safe) and keeps the string match only as a last-resort fallback. This stops the stall/resume path from depending on urllib3's message wording.

Preserving .part files across runs is what makes cross-run resume work, but partials are month-scoped, so a partial from an older source directory can never be resumed again — it just holds gigabytes forever. Starting a download run now prunes partials whose directory slug doesn't match the current one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened downloader timeout handling and cleanup: detect read timeouts by exception type, and prune only downloader-owned `.part` files from other directories to keep resume safe and disk usage low.

- **Bug Fixes**
  - Read timeouts: walk exception args and cause/context to detect `urllib3` `ReadTimeoutError` and `TimeoutError`, with a final string fallback. Removes dependence on `requests`/`urllib3` message wording and stabilizes resume behavior.
  - Partial pruning: before downloads, delete `.zip.{slug}.part` files whose directory slug doesn’t match the current one, and ignore unrelated `.part` files in shared temp dirs. Keeps only same-directory partials, freeing space and preventing bad cross-month resumes.

<sup>Written for commit ddd2ae97a4d08adedfb9839ee6a8ee6f6bfe401d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/caiopizzol/cnpj-data-pipeline/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

