### PR TITLE
chore(ci): pin semantic-release-ai-notes action to v0.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: AI Release Notes
         if: success()
-        uses: caiopizzol/semantic-release-ai-notes@main
+        uses: caiopizzol/semantic-release-ai-notes@v0.3.1
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: claude-haiku-4-5


### PR DESCRIPTION
Pins the AI release notes action to the v0.3.1 tag instead of tracking main, so release runs are reproducible and pick up upstream changes deliberately. v0.3.1 also carries the fix for the narration leak that landed in the v1.38.0 release body here (the notes are now schema-validated structured data rendered in code, not raw model text).

Depends on caiopizzol/semantic-release-ai-notes#1 being merged and released as v0.3.1 first; merging before that tag exists would make the release workflow fail on tag resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the release notes action to `v0.3.1` to make release runs reproducible and include the narration leak fix (notes are schema-validated and rendered in code). Merge only after the upstream `v0.3.1` tag is published to avoid workflow failures.

<sup>Written for commit 8b6dd210d12301fc42792d1969ebd59cf626eeaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/caiopizzol/cnpj-data-pipeline/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

