### PR TITLE
fix(downloader): reset the retry budget when a stalled attempt made progress

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -330,7 +330,16 @@ class Downloader:
         if zip_path.exists():
             zip_path.unlink()
 
-        for attempt in range(self.config.retry_attempts):
+        # retry_attempts bounds CONSECUTIVE failures without forward progress,
+        # not total failures: a stall that grew the .part file is the resume
+        # path working, and Receita routinely stalls every few dozen MB, so a
+        # large file can accumulate many productive stalls. Counting those
+        # against a fixed budget makes big files structurally undownloadable.
+        # Only a retry that adds no bytes (server wedged, restart-from-zero)
+        # burns an attempt.
+        progress_marker = part_path.stat().st_size if part_path.exists() else 0
+        failures_without_progress = 0
+        while True:
             try:
                 log(f"Downloading {filename}...")
                 self._download_zip_once(url, filename, zip_path, part_path)
@@ -343,11 +352,17 @@ class Downloader:
                     if record_stall is not None:
                         record_stall()
                 else:
-                    logger.warning(f"Download attempt {attempt + 1} failed: {e}")
-                if attempt < self.config.retry_attempts - 1:
-                    time.sleep(self.config.retry_delay)
+                    logger.warning(f"Download attempt failed: {e}")
+
+                part_size = part_path.stat().st_size if part_path.exists() else 0
+                if part_size > progress_marker:
+                    progress_marker = part_size
+                    failures_without_progress = 0
                 else:
+                    failures_without_progress += 1
+                if failures_without_progress >= self.config.retry_attempts:
                     raise
+                time.sleep(self.config.retry_delay)
 
     def _download_zip_once(self, url: str, filename: str, zip_path: Path, part_path: Path) -> None:
         offset = part_path.stat().st_size if part_path.exists() else 0

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -365,7 +365,16 @@ class TestDownloadAndExtract:
                 _ScriptedResponse(
                     chunks=[zip_content[:split_at], requests.exceptions.Timeout("stalled stream")],
                     headers={"content-length": str(len(zip_content))},
-                )
+                ),
+                # The retry resumes but receives nothing: no progress, budget exhausted.
+                _ScriptedResponse(
+                    chunks=[requests.exceptions.Timeout("stalled again")],
+                    headers={
+                        "content-range": f"bytes {split_at}-{len(zip_content) - 1}/{len(zip_content)}",
+                        "content-length": str(len(zip_content) - split_at),
+                    },
+                    status_code=206,
+                ),
             ]
         )
         monkeypatch.setattr(requests, "get", scripted_get)
@@ -454,6 +463,19 @@ class TestDownloadAndExtract:
                     },
                     status_code=206,
                 ),
+            ]
+            + [
+                # Productive attempts reset the budget; only these two
+                # empty-handed retries count against retry_attempts=2.
+                _ScriptedResponse(
+                    chunks=[],
+                    headers={
+                        "content-range": f"bytes {second_split}-{len(zip_content) - 1}/{len(zip_content)}",
+                        "content-length": str(len(zip_content) - second_split),
+                    },
+                    status_code=206,
+                )
+                for _ in range(2)
             ]
         )
         monkeypatch.setattr(requests, "get", scripted_get)
@@ -1161,10 +1183,7 @@ class TestResumeEdgeCases:
         scripted_get = _ScriptedGet(
             [
                 _ScriptedResponse(
-                    chunks=[
-                        zip_content[:4],
-                        requests.exceptions.ConnectionError("Connection reset by peer"),
-                    ],
+                    chunks=[requests.exceptions.ConnectionError("Connection reset by peer")],
                     headers={"content-length": str(len(zip_content))},
                 )
             ]
@@ -1232,3 +1251,53 @@ class TestStalePartialPruning:
 
         assert len(results) == 1
         assert not stale.exists()
+
+
+class TestRetryBudgetResetsOnProgress:
+    """Observed live 2026-07-08: Receita stalls big files every few dozen MB.
+    Each stall resumes with progress, so a fixed total-failure budget made
+    large files structurally undownloadable once stalls > retry_attempts."""
+
+    def test_more_stalls_than_retry_attempts_complete_when_each_makes_progress(self, downloader, tmp_path, monkeypatch):
+        downloader.config.keep_files = True
+        downloader.config.retry_attempts = 2
+        zip_content = _create_test_zip(tmp_path, {"CNAECSV.D51213": "0111301;Test" * 200})
+        total = len(zip_content)
+        cuts = [0, total // 4, total // 2, (total * 3) // 4]
+        responses = []
+        for i, start in enumerate(cuts):
+            end = cuts[i + 1] if i + 1 < len(cuts) else total
+            chunks = [zip_content[start:end]]
+            if end < total:
+                chunks.append(requests.exceptions.Timeout("stalled"))
+            headers = {"content-length": str(total - start)}
+            status = 200
+            if start:
+                headers["content-range"] = f"bytes {start}-{total - 1}/{total}"
+                status = 206
+            responses.append(_ScriptedResponse(chunks=chunks, headers=headers, status_code=status))
+        scripted_get = _ScriptedGet(responses)
+        monkeypatch.setattr(requests, "get", scripted_get)
+
+        result = downloader._download_and_extract("2024-03", "Cnaes.zip")
+
+        assert len(result) == 1
+        assert len(scripted_get.calls) == 4  # 3 stalls survived a budget of 2
+
+    def test_consecutive_no_progress_stalls_still_exhaust_the_budget(self, downloader, tmp_path, monkeypatch):
+        downloader.config.retry_attempts = 2
+        zip_content = _create_test_zip(tmp_path, {"CNAECSV.D51213": "0111301;Test"})
+
+        def stall():
+            return _ScriptedResponse(
+                chunks=[requests.exceptions.Timeout("wedged")],
+                headers={"content-length": str(len(zip_content))},
+            )
+
+        scripted_get = _ScriptedGet([stall(), stall()])
+        monkeypatch.setattr(requests, "get", scripted_get)
+
+        with pytest.raises(DownloadStalledError):
+            downloader._download_and_extract("2024-03", "Cnaes.zip")
+
+        assert len(scripted_get.calls) == 2


### PR DESCRIPTION
Found by a full-month download acceptance run against the live Receita server (2026-06 set, pipeline v1.38.1): the resume protocol, stall watchdog, and adaptive concurrency all worked, but Empresas1.zip stalled three times — each time resuming further along (0 → 11MB → 66MB) — and the third stall exhausted retry_attempts, failing the whole run. Receita stalls large files every few dozen MB, so any file big enough to stall more than retry_attempts times was structurally undownloadable, which defeats the point of resumable downloads.

retry_attempts now bounds consecutive failures without forward progress instead of total failures: a retry that grew the .part file resets the budget, while a wedged server (or a discard-and-restart that lands short of the previous offset) still burns attempts and fails after the same bound as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the download retry budget when a stalled attempt makes forward progress, so large Receita zips that stall repeatedly can still finish. Only consecutive retries that add no bytes now consume `retry_attempts`.

- **Bug Fixes**
  - Detect progress via `.part` growth and reset the failure counter when bytes are added.
  - No-progress retries still burn attempts and fail after the configured limit.
  - Added tests for progress-based resets and for consecutive no-progress exhaustion.

<sup>Written for commit 9a92cadbb75dd56f59a27497db774086c3687d12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/caiopizzol/cnpj-data-pipeline/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

