### PR TITLE
fix(downloader): gate every attempt on adaptive concurrency, back off no-progress retries

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -370,18 +370,23 @@ class Downloader:
             try:
                 log(f"Downloading {filename}...")
                 with adaptive.stream_permit() if adaptive is not None else nullcontext():
-                    self._download_zip_once(url, filename, zip_path, part_path)
+                    try:
+                        self._download_zip_once(url, filename, zip_path, part_path)
+                    except (DownloadStalledError, requests.exceptions.ConnectTimeout):
+                        # ConnectTimeout counts as server pressure alongside
+                        # stalls: a server that stops accepting connections
+                        # after stalling streams is telling us the same thing.
+                        # Record while the permit is still held, so waiters
+                        # wake to the degraded limit rather than racing one
+                        # more attempt through at the old concurrency.
+                        if adaptive is not None:
+                            adaptive.record_stall()
+                        raise
                 return
             except Exception as e:
                 if zip_path.exists():
                     zip_path.unlink()
 
-                # ConnectTimeout counts as server pressure alongside stalls:
-                # a server that stops accepting connections after stalling
-                # streams is telling us the same thing a stalled stream does.
-                if isinstance(e, (DownloadStalledError, requests.exceptions.ConnectTimeout)):
-                    if adaptive is not None:
-                        adaptive.record_stall()
                 if not isinstance(e, DownloadStalledError):
                     logger.warning(f"Download attempt failed: {e}")
 

--- a/downloader.py
+++ b/downloader.py
@@ -6,9 +6,10 @@ import re
 import time
 import zipfile
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
-from threading import Lock
+from threading import Condition, Lock
 from time import monotonic
 from typing import Callable, Iterator, List, Mapping, Tuple
 from xml.etree import ElementTree
@@ -59,6 +60,10 @@ class DownloadStalledError(DownloadIncompleteError):
     """Raised when a download stream stops yielding bytes past the stall timeout."""
 
 
+# Ceiling for the exponential no-progress retry backoff in _download_zip.
+MAX_RETRY_BACKOFF_SECONDS = 120
+
+
 @dataclass(frozen=True)
 class ConcurrencyDegradation:
     """A one-way adaptive concurrency change triggered by cumulative stalls."""
@@ -77,11 +82,33 @@ class AdaptiveDownloadConcurrency:
         self._next_degrade_at = self._stall_degrade_threshold
         self._stall_count = 0
         self._lock = Lock()
+        self._permits = Condition(self._lock)
+        self._active_streams = 0
 
     @property
     def current_concurrency(self) -> int:
         with self._lock:
             return self._current_concurrency
+
+    @contextmanager
+    def stream_permit(self) -> Iterator[None]:
+        """Gate one HTTP attempt (connect + stream) on the CURRENT concurrency.
+        _download_parallel only limits how many file downloads are submitted;
+        files already in flight when concurrency degrades would otherwise keep
+        reconnecting in parallel on every retry - observed live 2026-07-09 as
+        a 4-wide reconnect storm after degradation to 1, which Receita answered
+        with connect timeouts until the retry budget died. Every attempt must
+        hold a permit, so degradation serializes retries too."""
+        with self._permits:
+            while self._active_streams >= self._current_concurrency:
+                self._permits.wait()
+            self._active_streams += 1
+        try:
+            yield
+        finally:
+            with self._permits:
+                self._active_streams -= 1
+                self._permits.notify_all()
 
     @property
     def stall_count(self) -> int:
@@ -207,7 +234,7 @@ class Downloader:
 
         # Process reference files first (sequentially)
         for filename in reference_files:
-            for csv_path in self._download_and_extract(directory, filename, adaptive_concurrency.record_stall):
+            for csv_path in self._download_and_extract(directory, filename, adaptive_concurrency):
                 yield csv_path, filename
 
         # Process data files in parallel
@@ -236,7 +263,7 @@ class Downloader:
                         self._download_and_extract,
                         directory,
                         filename,
-                        adaptive_concurrency.record_stall,
+                        adaptive_concurrency,
                     )
                     future_to_filename[future] = filename
 
@@ -258,7 +285,7 @@ class Downloader:
         self,
         directory: str,
         filename: str,
-        record_stall: Callable[[], ConcurrencyDegradation | None] | None = None,
+        adaptive: AdaptiveDownloadConcurrency | None = None,
     ) -> List[Path]:
         """Download a single ZIP file and extract CSV files."""
         url = f"{self.config.base_url}/{directory}/{filename}"
@@ -271,7 +298,7 @@ class Downloader:
         if self.config.keep_files and zip_path.exists() and self._cached_zip_is_valid(zip_path):
             log(f"Using cached: {filename}")
         else:
-            self._download_zip(url, directory, filename, zip_path, log, record_stall)
+            self._download_zip(url, directory, filename, zip_path, log, adaptive)
 
         # Extract CSV files
         extracted_files = []
@@ -319,7 +346,7 @@ class Downloader:
         filename: str,
         zip_path: Path,
         log: Callable[[str], None],
-        record_stall: Callable[[], ConcurrencyDegradation | None] | None,
+        adaptive: AdaptiveDownloadConcurrency | None,
     ) -> None:
         """Download a ZIP through a resumable .part file and validate it."""
         # The .part name carries the source directory (month): CNPJ file names
@@ -342,16 +369,20 @@ class Downloader:
         while True:
             try:
                 log(f"Downloading {filename}...")
-                self._download_zip_once(url, filename, zip_path, part_path)
+                with adaptive.stream_permit() if adaptive is not None else nullcontext():
+                    self._download_zip_once(url, filename, zip_path, part_path)
                 return
             except Exception as e:
                 if zip_path.exists():
                     zip_path.unlink()
 
-                if isinstance(e, DownloadStalledError):
-                    if record_stall is not None:
-                        record_stall()
-                else:
+                # ConnectTimeout counts as server pressure alongside stalls:
+                # a server that stops accepting connections after stalling
+                # streams is telling us the same thing a stalled stream does.
+                if isinstance(e, (DownloadStalledError, requests.exceptions.ConnectTimeout)):
+                    if adaptive is not None:
+                        adaptive.record_stall()
+                if not isinstance(e, DownloadStalledError):
                     logger.warning(f"Download attempt failed: {e}")
 
                 part_size = part_path.stat().st_size if part_path.exists() else 0
@@ -362,7 +393,12 @@ class Downloader:
                     failures_without_progress += 1
                 if failures_without_progress >= self.config.retry_attempts:
                     raise
-                time.sleep(self.config.retry_delay)
+                # Exponential backoff on consecutive no-progress failures: a
+                # fixed delay re-hammers a refusing server on a tight cadence
+                # (observed as connect-timeout loops every ~35s); progress
+                # resets the backoff along with the failure budget.
+                backoff = self.config.retry_delay * (2 ** max(0, failures_without_progress - 1))
+                time.sleep(min(backoff, MAX_RETRY_BACKOFF_SECONDS))
 
     def _download_zip_once(self, url: str, filename: str, zip_path: Path, part_path: Path) -> None:
         offset = part_path.stat().st_size if part_path.exists() else 0

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1301,3 +1301,89 @@ class TestRetryBudgetResetsOnProgress:
             downloader._download_and_extract("2024-03", "Cnaes.zip")
 
         assert len(scripted_get.calls) == 2
+
+
+class TestAttemptLevelConcurrency:
+    """Live failure 2026-07-09: after degradation to 1, four in-flight file
+    workers kept reconnecting in parallel every ~35s and Receita answered
+    with connect timeouts until every retry budget died. Degradation must
+    govern attempts, not just file submissions."""
+
+    def test_stream_permit_blocks_attempts_beyond_degraded_concurrency(self):
+        import threading
+
+        adaptive = AdaptiveDownloadConcurrency(2, 1)
+        first_holds = threading.Event()
+        release_first = threading.Event()
+        second_acquired = threading.Event()
+
+        def first():
+            with adaptive.stream_permit():
+                first_holds.set()
+                release_first.wait(timeout=5)
+
+        def second():
+            with adaptive.stream_permit():
+                second_acquired.set()
+
+        t1 = threading.Thread(target=first)
+        t1.start()
+        assert first_holds.wait(timeout=5)
+
+        adaptive.record_stall()
+        assert adaptive.current_concurrency == 1
+
+        t2 = threading.Thread(target=second)
+        t2.start()
+        assert not second_acquired.wait(timeout=0.2), "second attempt ran despite degradation to 1"
+
+        release_first.set()
+        assert second_acquired.wait(timeout=5)
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+    def test_connect_timeout_counts_as_adaptive_stall_signal(self, downloader, monkeypatch):
+        downloader.config.retry_attempts = 1
+        adaptive = AdaptiveDownloadConcurrency(4, 3)
+        monkeypatch.setattr(
+            requests,
+            "get",
+            MagicMock(side_effect=requests.exceptions.ConnectTimeout("refused")),
+        )
+
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            downloader._download_zip(
+                "https://example/x.zip",
+                "2024-03",
+                "Cnaes.zip",
+                downloader.temp_path / "Cnaes.zip",
+                logging.getLogger(__name__).debug,
+                adaptive,
+            )
+
+        assert adaptive.stall_count == 1
+
+    def test_no_progress_retries_back_off_exponentially_with_a_cap(self, downloader, monkeypatch):
+        import downloader as downloader_module
+
+        downloader.config.retry_attempts = 4
+        downloader.config.retry_delay = 40
+        sleeps = []
+        monkeypatch.setattr(downloader_module.time, "sleep", sleeps.append)
+        monkeypatch.setattr(
+            requests,
+            "get",
+            MagicMock(side_effect=requests.exceptions.ConnectTimeout("refused")),
+        )
+
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            downloader._download_zip(
+                "https://example/x.zip",
+                "2024-03",
+                "Cnaes.zip",
+                downloader.temp_path / "Cnaes.zip",
+                logging.getLogger(__name__).debug,
+                None,
+            )
+
+        assert sleeps == [40, 80, 120]  # 40*2^2=160 capped at MAX_RETRY_BACKOFF_SECONDS

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1387,3 +1387,34 @@ class TestAttemptLevelConcurrency:
             )
 
         assert sleeps == [40, 80, 120]  # 40*2^2=160 capped at MAX_RETRY_BACKOFF_SECONDS
+
+    def test_stall_is_recorded_while_the_permit_is_still_held(self, downloader, monkeypatch):
+        """Waiters must wake to the degraded limit; recording after release
+        races one more attempt through at the old concurrency."""
+        downloader.config.retry_attempts = 1
+        adaptive = AdaptiveDownloadConcurrency(4, 1)
+        active_at_record = []
+        original = adaptive.record_stall
+
+        def spy():
+            active_at_record.append(adaptive._active_streams)
+            return original()
+
+        monkeypatch.setattr(adaptive, "record_stall", spy)
+        monkeypatch.setattr(
+            requests,
+            "get",
+            MagicMock(side_effect=requests.exceptions.ConnectTimeout("refused")),
+        )
+
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            downloader._download_zip(
+                "https://example/x.zip",
+                "2024-03",
+                "Cnaes.zip",
+                downloader.temp_path / "Cnaes.zip",
+                logging.getLogger(__name__).debug,
+                adaptive,
+            )
+
+        assert active_at_record == [1]


### PR DESCRIPTION
Second finding from the live full-month acceptance runs. After adaptive concurrency degraded 4→2→1, the four Empresas*.zip downloads already in flight kept reconnecting in parallel on every retry — degradation only gated *new file submissions* in _download_parallel, not attempts inside running futures. Receita responded to that four-wide reconnect cadence (one attempt per file every ~35s) with connect timeouts until every retry budget was exhausted.

Three changes, each mapped to a piece of that failure:

- AdaptiveDownloadConcurrency now issues stream permits: every HTTP attempt (connect + stream) must hold one, so degradation to 1 serializes retries even for files submitted earlier.
- ConnectTimeout counts as an adaptive stall signal — a server that stops accepting connections after stalling streams is expressing the same pressure a stalled stream does.
- Consecutive no-progress retries back off exponentially (retry_delay × 2^n, capped at 120s) instead of re-hammering on a fixed ~35s cadence; progress resets the backoff along with the failure budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates every HTTP attempt on adaptive concurrency, records stalls before releasing the permit, and adds exponential backoff for no-progress retries to stop reconnect storms after degradation. Also treats `requests.exceptions.ConnectTimeout` as a stall signal.

- **Bug Fixes**
  - Added attempt-level gating via `AdaptiveDownloadConcurrency.stream_permit()` so every connect+stream holds a permit, and record stalls while the permit is held so waiters see the degraded limit (no extra attempts slip through).
  - Count `requests.exceptions.ConnectTimeout` as an adaptive stall signal to trigger degradation when the server refuses connections.
  - Back off consecutive no-progress retries exponentially (`retry_delay * 2^n`, capped at 120s). Any progress resets both backoff and the failure budget.

<sup>Written for commit af6c7670830b5f06782cf7191cb5cfaf23fcfc6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/caiopizzol/cnpj-data-pipeline/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

