### PR TITLE
docs: document adaptive-concurrency and progress-aware retry config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,12 +18,19 @@ DOWNLOAD_WORKERS=4
 PROCESS_WORKERS=1
 
 # Network
+# RETRY_ATTEMPTS counts CONSECUTIVE failures without forward progress: a retry
+# that adds bytes to the .part file resets it, so a large file can survive many
+# productive stalls. RETRY_DELAY is the base for exponential backoff on
+# no-progress failures (doubles each time, capped at 120s).
 RETRY_ATTEMPTS=3
 RETRY_DELAY=5
 CONNECT_TIMEOUT=30
 READ_TIMEOUT=300
 STALL_TIMEOUT=30
 PROGRESS_LOG_INTERVAL=30
+# Cumulative stalls (or connect timeouts) at which download concurrency
+# degrades one step (DOWNLOAD_WORKERS -> 2 -> 1) for the rest of the run.
+STALL_DEGRADE_THRESHOLD=3
 
 # Loading strategy: "upsert" (default, keeps availability) or "replace" (faster, truncates tables)
 LOADING_STRATEGY=upsert

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ CONNECT_TIMEOUT=30
 READ_TIMEOUT=300
 STALL_TIMEOUT=30
 PROGRESS_LOG_INTERVAL=30
+STALL_DEGRADE_THRESHOLD=3  # Stalls acumulados até reduzir a concorrência
 KEEP_DOWNLOADED_FILES=false
 LOADING_STRATEGY=upsert  # "upsert" ou "replace"
 OUTPUT_FORMAT=postgres   # "postgres" ou "parquet"
@@ -118,6 +119,24 @@ PARQUET_OUTPUT_DIR=./parquet
 PARQUET_TYPED_OUTPUT=false  # Quando true, datas e numéricos saem tipados (Date, Float64, Int32)
 PROCESS_WORKERS=1        # Arquivos do mesmo grupo em paralelo (ex: 4)
 ```
+
+### Downloads resilientes
+
+O servidor da Receita costuma travar streams grandes (e recusa conexões
+quando várias baixam em paralelo). Os downloads são retomáveis via arquivo
+`.part`, e as variáveis acima não têm mais o sentido óbvio dos nomes:
+
+- `RETRY_ATTEMPTS` conta **falhas consecutivas sem progresso**, não falhas
+  totais. Qualquer byte novo gravado no `.part` zera o orçamento, então um
+  arquivo grande sobrevive a muitos stalls produtivos.
+- `RETRY_DELAY` é a base de um backoff exponencial (dobra a cada falha sem
+  progresso, teto de 120s), não um atraso fixo.
+- Stalls e connect timeouts repetidos reduzem a concorrência de download
+  (`DOWNLOAD_WORKERS` -> 2 -> 1) a partir de `STALL_DEGRADE_THRESHOLD`, sem
+  voltar a subir na mesma execução.
+- Cada tentativa HTTP (inclusive as retentativas) passa pela concorrência
+  adaptativa, então ao degradar para 1 as retentativas serializam em vez de
+  reconectar em paralelo.
 
 ### `DATABASE_URL`: parâmetros libpq
 


### PR DESCRIPTION
Adds STALL_DEGRADE_THRESHOLD to .env.example and the README config block, and a short note explaining that the download resilience work changed what the existing knobs mean: RETRY_ATTEMPTS now counts consecutive no-progress failures (any .part growth resets it), RETRY_DELAY is the base for exponential backoff capped at 120s, stalls and connect timeouts degrade concurrency, and every attempt — retries included — is gated by adaptive concurrency so retries serialize after degrading to 1.

Operators tune DOWNLOAD_WORKERS / RETRY_ATTEMPTS / RETRY_DELAY, and the new behavior is no longer obvious from the variable names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document adaptive concurrency and progress-aware retries for downloads to help operators tune `DOWNLOAD_WORKERS`, `RETRY_ATTEMPTS`, and `RETRY_DELAY` correctly. Adds `STALL_DEGRADE_THRESHOLD` to `.env.example` and updates the README to explain that retries reset on any `.part` growth, backoff doubles up to 120s, repeated stalls/connect timeouts degrade concurrency (`N -> 2 -> 1`), and retries serialize once degraded.

<sup>Written for commit 6cf834ad9985e3f03f2caa59766698cb1f11d686. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/caiopizzol/cnpj-data-pipeline/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

