### PR TITLE
docs(readme): esclarecer atualizações recorrentes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ brew install uv just
 ```bash
 cp .env.example .env
 just up      # Iniciar PostgreSQL
-just run     # Executar pipeline
+just run     # Processar a competência mais recente uma vez
 ```
 
 ## Via Docker
@@ -60,10 +60,10 @@ Imagem pronta publicada a cada release no GitHub Container Registry. Não precis
 # Listar meses disponíveis
 docker run --rm ghcr.io/caiopizzol/cnpj-data-pipeline --list
 
-# Processar um mês em um Postgres seu
+# Processar a competência mais recente uma vez em um Postgres seu
 docker run --rm \
   -e DATABASE_URL=postgres://user:pass@host:5432/cnpj \
-  ghcr.io/caiopizzol/cnpj-data-pipeline --month 2024-11
+  ghcr.io/caiopizzol/cnpj-data-pipeline
 
 # Exportar para Parquet (sem banco)
 docker run --rm \
@@ -95,8 +95,14 @@ just check   # Rodar todos (lint, format, test)
 just run                          # Processar mês mais recente
 just run --list                   # Listar meses disponíveis
 just run --month 2024-11          # Processar mês específico
-just run --month 2024-11 --force  # Forçar reprocessamento
+just run --month 2024-11 --force  # Reprocessar mês no PostgreSQL
 ```
+
+### Atualizações recorrentes
+
+Cada comando executa o pipeline uma vez e encerra. Sem `--month`, ele seleciona a competência mais recente disponível. No PostgreSQL, arquivos já processados são ignorados.
+
+Para manter a base atualizada, configure um cron job ou outro scheduler para executar periodicamente `just run` ou `docker compose run --rm pipeline`. Não use `--force` nas execuções agendadas.
 
 ## Configuração
 
@@ -161,8 +167,8 @@ Sobre `search_path`: o schema precisa existir antes (`CREATE SCHEMA cnpj;`), o l
 
 | Estratégia | Comando | Quando usar |
 |------------|---------|-------------|
-| `upsert` | `LOADING_STRATEGY=upsert just run` | Atualização incremental. Banco continua acessível durante a carga. |
-| `replace` | `LOADING_STRATEGY=replace just run` | Carga completa mensal. Mais rápido — faz TRUNCATE e insere direto. |
+| `upsert` | `LOADING_STRATEGY=upsert just run` | Insere registros novos e atualiza existentes. O banco continua acessível durante a carga. |
+| `replace` | `LOADING_STRATEGY=replace just run` | Substitui os dados da competência processada. Mais rápido, mas faz TRUNCATE antes da carga. |
 
 ### Formato de saída
 
@@ -226,7 +232,7 @@ Estes dados são **públicos e oficiais**, disponibilizados pela própria Receit
 |---|---|
 | **Fonte** | [Portal de Dados Abertos — CNPJ](https://dados.gov.br/dados/conjuntos-dados/cadastro-nacional-da-pessoa-juridica---cnpj) |
 | **Repositório** | [Receita Federal — Nextcloud](https://arquivos.receitafederal.gov.br/index.php/s/YggdBLfdninEJX9) |
-| **Atualização** | Mensal |
+| **Publicação da fonte** | Mensal, pela Receita Federal |
 | **Formato** | CSV (`;` separador, ISO-8859-1) |
 | **Base legal** | [Lei 12.527/2011](https://www.planalto.gov.br/ccivil_03/_ato2011-2014/2011/lei/l12527.htm) (Lei de Acesso à Informação), art. 8° |
 | **Regulamentação** | [Decreto 10.046/2019](https://www.planalto.gov.br/ccivil_03/_ato2019-2022/2019/decreto/D10046.htm) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # Usage:
 #   docker compose up -d postgres                          # Start database only
 #   docker compose run --rm pipeline --list                # List available months
-#   docker compose run --rm pipeline                       # Process latest month
+#   docker compose run --rm pipeline                       # Process latest month once
 #   docker compose run --rm pipeline --month 2024-11       # Process specific month
 #   docker compose down                                    # Stop services
 

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ down:
 db:
     docker exec -it cnpj-pipeline-postgres psql -U postgres -d cnpj
 
-# Run pipeline
+# Run pipeline once
 run *ARGS:
     uv run python main.py {{ARGS}}
 

--- a/main.py
+++ b/main.py
@@ -3,11 +3,11 @@
 CNPJ Data Pipeline - Download and process Brazilian company data from Receita Federal.
 
 Usage:
-    python main.py                    # Process latest month
+    python main.py                    # Process latest month once
     python main.py --list             # List available months
     python main.py --month 2024-11    # Process specific month
-    python main.py --month 2024-11 --force   # Force re-process
-    docker compose up                 # Run with Docker
+    python main.py --month 2024-11 --force   # Force PostgreSQL re-processing
+    docker compose up                 # Run once with Docker
 """
 
 import argparse
@@ -79,7 +79,12 @@ def parse_args():
     parser = argparse.ArgumentParser(description="CNPJ Data Pipeline - Download and process Brazilian company data")
     parser.add_argument("--list", "-l", action="store_true", help="List available months without processing")
     parser.add_argument("--month", "-m", type=str, help="Specific month to process (format: YYYY-MM, e.g., 2024-11)")
-    parser.add_argument("--force", "-f", action="store_true", help="Force re-processing even if already processed")
+    parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Force PostgreSQL re-processing even if already processed",
+    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
Esclarece que cada execução do pipeline roda uma vez e que atualizações recorrentes no PostgreSQL dependem de um agendador externo, evitando que a publicação mensal da Receita seja confundida com automação embutida. A dúvida surgiu em #104.

- Mantém a orientação junto aos comandos que as pessoas já usam
- Separa a frequência de publicação da Receita da frequência de execução do pipeline
- Limita a orientação recorrente ao PostgreSQL, cujo controle de arquivos processados permite execuções repetidas

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Esclarece que cada execução do pipeline roda uma vez e termina; recorrência exige agendador externo (ex.: cron). Atualiza o README (nova seção de atualizações recorrentes, exemplos e tabela da fonte), comentários em `docker-compose.yml` e `justfile`, e mensagens do CLI (inclui que `--force` reprocessa no PostgreSQL).

<sup>Written for commit af664527a5546110d218f12a64d9db4274f1ecbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/caiopizzol/cnpj-data-pipeline/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

