### PR TITLE
chore(cubic): simplify review configuration

### DIFF
--- a/.cubic/agents/data-contracts.md
+++ b/.cubic/agents/data-contracts.md
@@ -1,7 +1,0 @@
-# Persisted data contract invariant
-
-Each RFB record has one compatible contract across positional CSV parsing, transformations, PostgreSQL loading, Parquet output, recipes, and documentation. A source layout, output column, type, table name, or identity change must keep `COLUMNS`, `OUTPUT_COLUMNS`, transformation output order, `initial.sql`, conflict behavior, Parquet schema versioning, recipe joins and projections, migration guidance, and contract tests aligned wherever they are affected. PostgreSQL and Parquet may use different physical types or metadata columns, but they must preserve the same logical source rows and stable identities.
-
-Identity keys must use the stable canonical fields that distinguish real records. Masked or non-unique source attributes cannot be assumed unique, and mutable attributes cannot become identity fields merely to resolve a collision. Derived recipes may intentionally expose a narrower or enriched schema when their documented contract says so; they must still join through the current canonical keys without multiplying or dropping source rows unintentionally.
-
-Violating this invariant can silently assign values to the wrong fields, collapse distinct records during upsert, break joins, make loading strategies disagree, or publish a Parquet schema whose metadata does not warn consumers about an incompatible change.

--- a/.cubic/agents/pipeline-completion.md
+++ b/.cubic/agents/pipeline-completion.md
@@ -1,7 +1,0 @@
-# Pipeline completion invariant
-
-A source file or source month is complete only after every selected output is durable. PostgreSQL processing must commit every batch and record the source with `mark_processed(directory, filename)` before deleting the extracted CSV. Parquet processing must close each table successfully, complete any configured post-file command, and close all tables before publishing the success manifest. Worker, transformation, write, commit, flush, and post-file-command failures must reach the coordinator and make the run fail.
-
-Expected exceptions are inputs explicitly skipped because the same source directory and filename were already recorded as processed, temporary encoding copies removed while the original source remains recoverable, and cleanup performed after the durable output or an explicit failure is already known. `KEEP_DOWNLOADED_FILES` changes retention only; it does not change completion criteria.
-
-Violating this invariant can publish an incomplete month, permanently skip missing rows on the next run, delete the only recoverable input, or present stale output metadata as a successful export.

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -3,24 +3,5 @@
 version: 1
 
 reviews:
-  custom_rules:
-    - name: Preserve pipeline completion semantics
-      file_paths:
-        - .cubic/agents/pipeline-completion.md
-      include:
-        - main.py
-        - processor.py
-        - database.py
-        - parquet_writer.py
-
-    - name: Keep persisted data contracts aligned
-      file_paths:
-        - .cubic/agents/data-contracts.md
-      include:
-        - processor.py
-        - database.py
-        - parquet_writer.py
-        - initial.sql
-        - recipes/**
-        - docs/data-schema.md
-        - docs/post-processing.md
+  custom_instructions: >-
+    Focus review on semantic regressions that could publish incomplete monthly output or make the same Receita Federal record differ across CSV transformation, PostgreSQL, and Parquet. Flag completion state or input cleanup that can occur before every selected output is durable, and contract changes that leave column order, keys, types, recipes, documentation, or Parquet schema metadata inconsistent.


### PR DESCRIPTION
Consolidates Cubic's repository guidance into one focused review instruction so semantic pipeline risks remain visible without maintaining custom agents or consuming their limited slots.

- Keeps durability and cross-output contract regressions visible in normal reviews.
- Preserves all five custom-agent slots for future demonstrated needs.
- Lets organization, dashboard, and built-in workflow settings continue to apply.